### PR TITLE
Adding scenario for signing in public CI tooling

### DIFF
--- a/scenarios.md
+++ b/scenarios.md
@@ -287,9 +287,9 @@ If a user does not have a specific key for a given artifact, verified using a th
 1. Users must be able to to access a chain of trust that links the signing key for a particular artifact to a trusted root.
 1. Users must be able to configure roots of trust.
 
-### Scenario #13: Signing with Public CI Tooling
+### Scenario #13: Signing OSS Projects with Public CI Tooling
 
-A user building images using CI tooling on public infrastructure (e.g. GitHub Actions) would like to have a CI step to easily add signing to their image builds.
+A user building public images using CI tooling on public infrastructure (e.g. an OSS project with GitHub Actions) would like to have a CI step to easily add signing to their image builds.
 
 1. The user adds a CI step to their build pipeline, preferrably as a copy/paste with minimal configuration.
 1. The image is automatically signed as CI builds run.

--- a/scenarios.md
+++ b/scenarios.md
@@ -296,7 +296,7 @@ A user building public images using CI tooling on public infrastructure (e.g. an
 
 **Implications of this requirement:**
 
-1. Users would prefer to not include long lived private signing keys in the public infrastructure for security reasons.
+1. Users should not need to create a secret containing sensitive data that could be leaked in a malicious pull request.
 1. Users should not need to setup additional external servers for key management.
 
 ## Open Discussions

--- a/scenarios.md
+++ b/scenarios.md
@@ -287,6 +287,18 @@ If a user does not have a specific key for a given artifact, verified using a th
 1. Users must be able to to access a chain of trust that links the signing key for a particular artifact to a trusted root.
 1. Users must be able to configure roots of trust.
 
+### Scenario #13: Signing with Public CI Tooling
+
+A user building images using CI tooling on public infrastructure (e.g. GitHub Actions) would like to have a CI step to easily add signing to their image builds.
+
+1. The user adds a CI step to their build pipeline, preferrably as a copy/paste with minimal configuration.
+1. The image is automatically signed as CI builds run.
+
+**Implications of this requirement:**
+
+1. Users would prefer to not include long lived private signing keys in the public infrastructure for security reasons.
+1. Users should not need to setup additional external servers for key management.
+
 ## Open Discussions
 
 * What is the relationship between a signature, an artifact and a registry?


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

This is a response to seeing other signing tooling getting direct support in GitHub Actions and trying to capture that requirement with the Notary project.

Ref: <https://github.blog/2021-12-06-safeguard-container-signing-capability-actions/>