### PR TITLE
Markdown linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A current overview of Notary v2, including a collection of requirements & scenar
 
 ## Project Status
 
-The Notary v2 project is in early development and design documents should not be considered final. Please refer to the [milestones](https://github.com/notaryproject/notaryproject/milestones) or [attend](#contributing--conversations) the weekly meetings for details on the roadmap.
+The Notary v2 project is in early development and design documents should not be considered final.
+Please refer to the [milestones](https://github.com/notaryproject/notaryproject/milestones) or [attend](#contributing--conversations) the weekly meetings for details on the roadmap.
 
 ## TOC
 
@@ -26,7 +27,10 @@ Additional details for Notary v2 efforts:
 
 ![Notary v2 scenarios](./media/notary-e2e-scenarios.svg)
 
-Notary v2 provides for multiple signatures of an [OCI Artifact][oci-artifacts] (including container images) to be persisted in an [OCI conformant][oci-distribution-conformance] registry. Artifacts are signed (`nv2 sign`) with private keys, and validated with public keys (`nv2 verify`). To support user deployment flows, signing an OCI Artifact will not change the `@digest` or `artifact:tag` reference. To support content movement across multiple certification boundaries, artifacts and their signatures will be easily copied within and across [OCI conformant][oci-distribution-conformance] registries.
+Notary v2 provides for multiple signatures of an [OCI Artifact][oci-artifacts] (including container images) to be persisted in an [OCI conformant][oci-distribution-conformance] registry.
+Artifacts are signed (`nv2 sign`) with private keys, and validated with public keys (`nv2 verify`).
+To support user deployment flows, signing an OCI Artifact will not change the `@digest` or `artifact:tag` reference.
+To support content movement across multiple certification boundaries, artifacts and their signatures will be easily copied within and across [OCI conformant][oci-distribution-conformance] registries.
 
 ![Notary v2 dependent projects](./media/oss-project-sequence.svg)
 
@@ -92,7 +96,10 @@ docker push registry.acme-rockets.io/net-monitor:v1
 
 ## The Notary v2 Journey
 
-Notary v2 [kicked off in December of 2019][notaryv2-kickoff] with a [broad range of attendees][kickoff-attendees]. The effort defined success goals, including adoption by all major vendors & projects, enabling content to be signed and flow within and across [OCI distribution-spec conformant][oci-distribution-conformance] registries. Throughout 2020, the group agreed upon a set of [Notary v2 requirements][nv2-requirements] and [scenarios][nv2-scenarios] enabling spec and design conversations to be grounded in a set of [goals][nv2-requirements] and [non-goals][non-requirements]. Prototypes, based on the requirements have started, focusing on the primary areas on innovations.
+Notary v2 [kicked off in December of 2019][notaryv2-kickoff] with a [broad range of attendees][kickoff-attendees].
+The effort defined success goals, including adoption by all major vendors & projects, enabling content to be signed and flow within and across [OCI distribution-spec conformant][oci-distribution-conformance] registries.
+Throughout 2020, the group agreed upon a set of [Notary v2 requirements][nv2-requirements] and [scenarios][nv2-scenarios] enabling spec and design conversations to be grounded in a set of [goals][nv2-requirements] and [non-goals][non-requirements].
+Prototypes, based on the requirements have started, focusing on the primary areas on innovations.
 
 ## Top Areas of Focus
 
@@ -108,17 +115,24 @@ A Notary v2 signature would attest to the digest of an artifact, associating it 
 
 ### Registry Persistance, Discovery and Retrieval
 
-An artifact must be capable of being pushed to a registry, with a signature being added independently from the artifact. This enables the originating author of the content to sign the artifact, and subsequent entities to add additional signatures, attesting to its validity as they determine.
+An artifact must be capable of being pushed to a registry, with a signature being added independently from the artifact.
+This enables the originating author of the content to sign the artifact, and subsequent entities to add additional signatures, attesting to its validity as they determine.
 
-The Notary v2 workflow ([outlined in Scenario #0](https://github.com/notaryproject/requirements/blob/main/scenarios.md#scenario-0-build-publish-consume-enforce-policy-deploy)) enables Wabbit Networks to sign their `net-monitor` software. Docker Hub may endorse Wabbit Networks software, providing an aggregator certification by adding a Docker Hub signature. This would allow customers like ACME Rockets to not necessarily know of small vendors like Wabbit Networks, but allow the ACME Rockets engineering team to pull Docker Certified content. As ACME Rockets imports the content, scans and validates it meets their requirements, they add an additional ACME Rockets signature, which must exist for any production usage within the ACME Rockets environment.
+The Notary v2 workflow ([outlined in Scenario #0](https://github.com/notaryproject/requirements/blob/main/scenarios.md#scenario-0-build-publish-consume-enforce-policy-deploy)) enables Wabbit Networks to sign their `net-monitor` software.
+Docker Hub may endorse Wabbit Networks software, providing an aggregator certification by adding a Docker Hub signature.
+This would allow customers like ACME Rockets to not necessarily know of small vendors like Wabbit Networks, but allow the ACME Rockets engineering team to pull Docker Certified content.
+As ACME Rockets imports the content, scans and validates it meets their requirements, they add an additional ACME Rockets signature, which must exist for any production usage within the ACME Rockets environment.
 
 #### Registry Persistance and Retrieval
 
-Registry persistance and retrieval are defined through the [OCI distribution-spec][oci-distribution-spec], with [OCI Artifacts][oci-artifacts] capabilities to store non-container images. No additional changes are known at this time.
+Registry persistance and retrieval are defined through the [OCI distribution-spec][oci-distribution-spec], with [OCI Artifacts][oci-artifacts] capabilities to store non-container images.
+No additional changes are known at this time.
 
 #### Registry Discovery
 
-Registry discovery of linked artifacts enables finding a signature, based on the target artifact. In the Notary v2 example, the ACME Rockets production servers must be capable of efficiently finding the ACME Rockets signature for the `net-monitor:v1` image. Once the signature is identified, through a content addressable digest, the Notary v2 client may validate the signature.
+Registry discovery of linked artifacts enables finding a signature, based on the target artifact.
+In the Notary v2 example, the ACME Rockets production servers must be capable of efficiently finding the ACME Rockets signature for the `net-monitor:v1` image.
+Once the signature is identified, through a content addressable digest, the Notary v2 client may validate the signature.
 
 ### Key Management
 
@@ -136,11 +150,17 @@ Key revocation must support air-gap environments, enabling users to validate key
 
 ## Stages of Development
 
-To deliver Notary v2, we recognized the need of experts from multiple backgrounds, experiences and skill sets. The various perspectives were needed to assure we learned from past efforts and learned from subject matter experts.
+To deliver Notary v2, we recognized the need of experts from multiple backgrounds, experiences and skill sets.
+The various perspectives were needed to assure we learned from past efforts and learned from subject matter experts.
 
-As subject matter experts converged, we found it difficult for the various SMEs to understand other components of the end to end workflow. The typical Open Source model for authoring specs involves “writing it down”. Contributors Create a pull request on some markdown so all can review. However, we learned _The problem isn’t in the writing, it’s in the reading._
+As subject matter experts converged, we found it difficult for the various SMEs to understand other components of the end to end workflow.
+The typical Open Source model for authoring specs involves “writing it down”.
+Contributors Create a pull request on some markdown so all can review.
+However, we learned _The problem isn’t in the writing, it’s in the reading._
 
-To facilitate better communications across the skill sets, respecting everyone's time, we recognized the need to invest in models and prototypes. We followed the design patterns of other large, complex projects like Antoni Gaudí's design of [The Sagrada Famila](https://simple.wikipedia.org/wiki/Sagrada_Fam%C3%ADlia). The [sketch, prototype, build approach](https://stevelasker.blog/2020/07/31/sketch-prototype-build/) would enable the various experts to focus on their component, while understanding where they plug-into other components of the design.
+To facilitate better communications across the skill sets, respecting everyone's time, we recognized the need to invest in models and prototypes.
+We followed the design patterns of other large, complex projects like Antoni Gaudí's design of [The Sagrada Famila](https://simple.wikipedia.org/wiki/Sagrada_Fam%C3%ADlia).
+The [sketch, prototype, build approach](https://stevelasker.blog/2020/07/31/sketch-prototype-build/) would enable the various experts to focus on their component, while understanding where they plug-into other components of the design.
 
 As a result, we identified the following stages of the Notary v2 effort:
 
@@ -157,7 +177,8 @@ Throughout the Notary v2 effort, updates to the stages of development and areas 
 
 Regular conversations for Notary v2 occur on the [Cloud Native Computing Slack](https://app.slack.com/client/T08PSQ7BQ/CQUH8U287?) channel.
 
-Weekly meetings occur each Monday. Please see the [CNCF Calendar](https://www.cncf.io/community/calendar/) for details.
+Weekly meetings occur each Monday.
+Please see the [CNCF Calendar](https://www.cncf.io/community/calendar/) for details.
 
 Meeting notes are captured on [hackmd.io](https://hackmd.io/_vrqBGAOSUC_VWvFzWruZw).
 

--- a/definitions-terms.md
+++ b/definitions-terms.md
@@ -4,77 +4,85 @@ A collection of definitions and terms used within this repository.
 
 ## TOC
 
-* [Fingerprint](#fingerprint)
-* [Fully Qualified Artifact Reference](#registry-fully-qualified-reference)
-* [OCI Annotations](#oci-annotations)
-* [OCI Descriptor](#oci-descriptor)
-* [OCI Index](#oci-index)
-* [OCI Manifest](#oci-manifest)
-* [Registry](#registry)
-* [Repo/Repository](#repo/repository)
-* [Repository Path](#repository-path)
-* [SBoM](#sbom)
-* [Subject](#subject)
-* [Tag](#tag)
+- [Fingerprint](#fingerprint)
+- [Fully Qualified Artifact Reference](#registry-fully-qualified-reference)
+- [OCI Annotations](#oci-annotations)
+- [OCI Descriptor](#oci-descriptor)
+- [OCI Index](#oci-index)
+- [OCI Manifest](#oci-manifest)
+- [Registry](#registry)
+- [Repo/Repository](#repo/repository)
+- [Repository Path](#repository-path)
+- [SBoM](#sbom)
+- [Subject](#subject)
+- [Tag](#tag)
 
 ## Artifact / Image
 
-Artifacts are a generalization of how images are stored in an instance of the [OCI Distribution Spec][oci-distribution-spec]. An [OCI Image][oci-image] is a type of [OCI Artifact][oci-artifact]. When referencing artifacts, within a [fully qualified reference](#registry-fully-qualified-reference), the artifact is right most element of the namespace, combined with the `:tag`.  
+Artifacts are a generalization of how images are stored in an instance of the [OCI Distribution Spec][oci-distribution-spec].
+An [OCI Image][oci-image] is a type of [OCI Artifact][oci-artifact].
+When referencing artifacts, within a [fully qualified reference](#registry-fully-qualified-reference), the artifact is right most element of the namespace, combined with the `:tag`.
 Reference: [OCI Artifacts][oci-artifact]  
-![](./media/artifact-ref.png)  
-
+![artifact name and tag](./media/artifact-ref.png)
 
 ## Fingerprint
 
-A short identifier of a given public key.  
+A short identifier of a given public key.
 Reference: [Fingerprint][fingerprint]
-
 
 ## OCI Annotations
 
-A key-value map that can be associated with [OCI Descriptors][oci-descriptor] and [OCI Image manifests][oci-manifest].  
+A key-value map that can be associated with [OCI Descriptors][oci-descriptor] and [OCI Image manifests][oci-manifest].
 OCI spec reference: [OCI Annotations][oci-annotations]
 
 ## OCI Descriptor
 
-A structure describing content, including the media type, a content-addressable digest, the size, and other properties. Descriptors are used to describe layers and configuration in a manifest.  
+A structure describing content, including the media type, a content-addressable digest, the size, and other properties.
+Descriptors are used to describe layers and configuration in a manifest.
 OCI spec reference: [OCI Descriptor][oci-descriptor]
 
 ## OCI Index
 
-A higher-level collection of [image manifests][oci-manifest], or other [oci indexes][oci-index], typically used to describe platform-specific (architecture and operating-system) images that can be identified collectively and referred to together. The specific image manifests are identified by modified [descriptors][oci-descriptor] with additional properties and restrictions. [OCI Artifacts][oci-artifact] are another use-case for indexes where an OCI Index can reference a collection of artifacts, such as an image, a deployment chart, its SBoM and deployment configuration references.
+A higher-level collection of [image manifests][oci-manifest], or other [oci indexes][oci-index], typically used to describe platform-specific (architecture and operating-system) images that can be identified collectively and referred to together.
+The specific image manifests are identified by modified [descriptors][oci-descriptor] with additional properties and restrictions.
+[OCI Artifacts][oci-artifact] are another use-case for indexes where an OCI Index can reference a collection of artifacts, such as an image, a deployment chart, its SBoM and deployment configuration references.
 OCI spec reference: [OCI Image Index][oci-index]
 
 ## OCI Manifest
 
-A description of an [artifact][oci-artifact]. The manifest references optional configuration and blobs (layers) as content-addressable references ([descriptors][oci-descriptor]).  Artifacts may be container images, helm charts or other artifact types that may be signed and stored in a registry.    
+A description of an [artifact][oci-artifact].
+The manifest references optional configuration and blobs (layers) as content-addressable references ([descriptors][oci-descriptor]).
+Artifacts may be container images, helm charts or other artifact types that may be signed and stored in a registry.
 OCI spec reference: [OCI Image Manifest][oci-manifest]
 
 ## Registry
 
-A registry is a collection of [OCI Indexes][oci-index] and [OCI Manifests][oci-manifest] for a specific org or entity.  
+A registry is a collection of [OCI Indexes][oci-index] and [OCI Manifests][oci-manifest] for a specific org or entity.
 A unique registry may be uniquely identified with a domain or a root namespace:  
-![](./media/unique-registry-domain-ref.png)  
-![](./media/unique-registry-namespace-ref.png)
+![registry name](./media/unique-registry-domain-ref.png)
+![registry and namespace](./media/unique-registry-namespace-ref.png)
 
 ## Repo/Repository
 
-A repo/repository refers to the unique location, within a registry. When referring to a repo, the registry is assumed, based on the context.  
-![](./media/registry-repo-ref.png)
+A repo/repository refers to the unique location, within a registry.
+When referring to a repo, the registry is assumed, based on the context.
+![registry and repository](./media/registry-repo-ref.png)
 
 ## Repository Path
 
-A path, within the [unique registry org](#multi-tenant-registry), up to, but not including the repository (repo) name.  
-![](./media/registry-namespace-ref.png)
+A path, within the [unique registry org](#multi-tenant-registry), up to, but not including the repository (repo) name.
+![repository path](./media/registry-namespace-ref.png)
 
 ## Registry: Fully Qualified Reference
 
-In order to deploy an artifact, a fully qualified reference is required. This includes the unique registry, namespace, repo and tag.  
-![](./media/fully-qualified-artifact-ref.png)
+In order to deploy an artifact, a fully qualified reference is required.
+This includes the unique registry, namespace, repo and tag.
+![fully qualified reference](./media/fully-qualified-artifact-ref.png)
 
 ## SBoM
 
-Represents a generic, non-project specific, reference to a Software Bill of Materials. Similar to the automotive industry which tracks the components that make up a vehicle, the SBoM may contain the list of packages used within the artifact, the compiler and version used to build the artifact and other relevant information.  
+Represents a generic, non-project specific, reference to a Software Bill of Materials.
+Similar to the automotive industry which tracks the components that make up a vehicle, the SBoM may contain the list of packages used within the artifact, the compiler and version used to build the artifact and other relevant information.
 Additional reference: [Software bill of materials][sbom]
 
 ## Subject
@@ -83,15 +91,15 @@ The data that is signed.
 
 ## Tag
 
-Information that represents a version, or platform specific version of the artifact. 
-eg:
+Information that represents a version, or platform specific version of the artifact.
+E.g.:
+
 - `example.com/org/namespace/artifact:tag`
 - `org.example.com/namespace/artifact:tag`
 - `org.example.com/databases/somedb:v1` (multi-arch tag)
 - `org.example.com/databases/somedb:v1-alpine` (platform specific tag)
 - `org.example.com/databases/somedb:v1-windows` (platform specific tag)
 - `org.example.com/databases/somedb:v1-helm` (helm chart to deploy a platform specific image)
-
 
 [fingerprint]:           https://en.wikipedia.org/wiki/Public_key_fingerprint
 [oci-annotations]:       https://github.com/opencontainers/image-spec/blob/master/annotations.md

--- a/key-revocation.md
+++ b/key-revocation.md
@@ -1,76 +1,97 @@
 # Key Revocation
 
-One of the goals of Notary v2 is to build in solutions for key revocation that are easy to use and ensure that users will always use non-compromised keys. This document discusses some potential mechanisms for key revocation.
+One of the goals of Notary v2 is to build in solutions for key revocation that are easy to use and ensure that users will always use non-compromised keys.
+This document discusses some potential mechanisms for key revocation.
 
-In existing systems, there are three main approaches to key revocation: automatic revocation through key expiration, key revocation lists, and providing a list of trusted keys. This document discusses some of the benefits and pitfalls of each of these techniques, and how some of these techniques are combined to provide a holistic approach to key revocation.
-
+In existing systems, there are three main approaches to key revocation: automatic revocation through key expiration, key revocation lists, and providing a list of trusted keys.
+This document discusses some of the benefits and pitfalls of each of these techniques, and how some of these techniques are combined to provide a holistic approach to key revocation.
 
 ## Key Expiration
 
-Adding an expiration time to every key allows keys to automatically be revoked after a certain period of time. The expiration time is usually included with the key, and signed by a trusted issuing key, so that it is easy for users to find. This technique does not require any action from the key holder, and ensures that users will have to refresh their trusted keys before those keys expire.
+Adding an expiration time to every key allows keys to automatically be revoked after a certain period of time.
+The expiration time is usually included with the key, and signed by a trusted issuing key, so that it is easy for users to find.
+This technique does not require any action from the key holder, and ensures that users will have to refresh their trusted keys before those keys expire.
 
-However, if a key is compromised before it expires, key expiration alone does not protect users. An attacker with the compromised key could sign arbitrary images or metadata until the key's expiration time.
+However, if a key is compromised before it expires, key expiration alone does not protect users.
+An attacker with the compromised key could sign arbitrary images or metadata until the key's expiration time.
 
 Pros:
-* No action required from key holder
-* Simple: only requires a timestamp
+
+- No action required from key holder
+- Simple: only requires a timestamp
 
 Cons:
-* Keys can't be revoked before expiration
-* Artifacts must be re-signed after expiration, unless a timestamping service is used.
 
+- Keys can't be revoked before expiration
+- Artifacts must be re-signed after expiration, unless a timestamping service is used.
 
 ## Key revocation lists (Deny lists)
 
-Distributing a list of revoked keys allows key holders to notify users quickly if a key is compromised or lost. Users can check against the key revocation list before using a key to verify signatures. This technique is more flexible than key expiration times, and allows for more current information about key security.
+Distributing a list of revoked keys allows key holders to notify users quickly if a key is compromised or lost.
+Users can check against the key revocation list before using a key to verify signatures.
+This technique is more flexible than key expiration times, and allows for more current information about key security.
 
-However, the user must be able to ensure that the key revocation list is accurate and up to date. If an attacker is able to replay an old revocation list, or show different versions to different registries, the user may continue to trust compromised keys. Therefore the distribution of the key revocation list must allow the user to verify authenticity and timeliness.
+However, the user must be able to ensure that the key revocation list is accurate and up to date.
+If an attacker is able to replay an old revocation list, or show different versions to different registries, the user may continue to trust compromised keys.
+Therefore the distribution of the key revocation list must allow the user to verify authenticity and timeliness.
 
 Also, for security reasons, keys cannot be removed from a key revocation list, so the list will grow larger and larger over time and may eventually have a noticeable bandwidth impact, although this can be mitigated by combining key revocation lists with keys that expire.
 
 Pros:
-* Allows key revocation at any time
-* Anyone can add a key to the revocation list
+
+- Allows key revocation at any time
+- Anyone can add a key to the revocation list
 
 Cons:
-* Distribution of the key revocation list needs to be secured and verified for timeliness to prevent replays
-* Additional maintenance overhead
-* What to do when the revocation list query fails?
-* Revocation lists must be synchronized between registries.
 
+- Distribution of the key revocation list needs to be secured and verified for timeliness to prevent replays
+- Additional maintenance overhead
+- What to do when the revocation list query fails?
+- Revocation lists must be synchronized between registries.
 
 ## List of trusted keys (Allow lists)
 
-Instead of distributing untrusted keys, this method distributes a list of currently trusted keys. If a key needs to be revoked, it is removed from the list of trusted keys. This technique has the added benefit of ensuring that users have access to the new trusted key as soon as they learn of a revocation.
+Instead of distributing untrusted keys, this method distributes a list of currently trusted keys.
+If a key needs to be revoked, it is removed from the list of trusted keys.
+This technique has the added benefit of ensuring that users have access to the new trusted key as soon as they learn of a revocation.
 
 Similar to revocation lists, the list of trusted keys must be securely distributed and include mechanisms for the user to verify timeliness.
 
 Pros:
-* Allows key revocation at any time
-* Can be combined with key distribution
-* Does not require an additional query
+
+- Allows key revocation at any time
+- Can be combined with key distribution
+- Does not require an additional query
 
 Cons:
-* Distribution of trusted key list needs to be secured and verified for timeliness to prevent replays
-* Additional maintenance overhead
 
+- Distribution of trusted key list needs to be secured and verified for timeliness to prevent replays
+- Additional maintenance overhead
 
 ## Combining explicit and implicit revocation
 
-A final option is to use a combination of the first and third techniques to achieve both implicit and explicit key revocation. By using a hierarchical combination of keys, a trusted root key can delegate signing to various keys that expire. These keys may be revoked before that expiration time by replacing the key listed in the delegation. Additionally, artifacts may be signed by more than one key, allowing automated tooling to provide short lived signatures that verify the signer and artifact have not been revoked. Clients then verify the necessary collection of signatures is found on the artifact.
+A final option is to use a combination of the first and third techniques to achieve both implicit and explicit key revocation.
+By using a hierarchical combination of keys, a trusted root key can delegate signing to various keys that expire.
+These keys may be revoked before that expiration time by replacing the key listed in the delegation.
+Additionally, artifacts may be signed by more than one key, allowing automated tooling to provide short lived signatures that verify the signer and artifact have not been revoked.
+Clients then verify the necessary collection of signatures is found on the artifact.
 
 This method allows signers to have relatively long lived keys, to simplify their workflow and avoid needing to resign the artifacts themselves, while enabling timely revoking of the signing key or a single artifact signature.
 
-For efficiency, a meta-artifact can be created and maintained, containing references to a collection currently signed artifacts. And the short lived signature can be created for this single artifact, rather than every artifact individually. This meta-artifact would need to be updated whenever the collection of artifacts changes and parsed when validating any artifact.
+For efficiency, a meta-artifact can be created and maintained, containing references to a collection currently signed artifacts.
+And the short lived signature can be created for this single artifact, rather than every artifact individually.
+This meta-artifact would need to be updated whenever the collection of artifacts changes and parsed when validating any artifact.
 
 Pros:
-* Allows key revocation at any time
-* Keys will expire and so will not be used forever
-* Individual artifact signatures may be quickly revoked
-* Signers do not need to frequently resign all artifacts
-* Can be combined with key distribution, so verifiers only need to trust the root key, all delegated keys can be verified against this
+
+- Allows key revocation at any time
+- Keys will expire and so will not be used forever
+- Individual artifact signatures may be quickly revoked
+- Signers do not need to frequently resign all artifacts
+- Can be combined with key distribution, so verifiers only need to trust the root key, all delegated keys can be verified against this
 
 Cons:
-* Requires maintenance of an automated system to refresh short lived signatures
-* A root key compromise requires updating all signers, clients, and signatures on the artifacts
-* Updating short lived signatures on a large number of artifacts may encounter scaling challenges and loses some of the caching efficiencies of content addressable storage in registries
+
+- Requires maintenance of an automated system to refresh short lived signatures
+- A root key compromise requires updating all signers, clients, and signatures on the artifacts
+- Updating short lived signatures on a large number of artifacts may encounter scaling challenges and loses some of the caching efficiencies of content addressable storage in registries

--- a/keymanagementrequirements.md
+++ b/keymanagementrequirements.md
@@ -1,79 +1,124 @@
 # Overview
+
 Key management for container signing can be broadly categorized into three general use cases:
+
 - Key Setup/Signing (Key managment and integrations with client tooling for generating signatures.)
 - Deployment configurations (Configuring trust policies and which keys to trust for artifacts.)
-- Signature Validity (Expiry, Revocation and/or Trusted Update List. Mechanism to update information on the validity of signatures.)
+- Signature Validity (Expiry, Revocation and/or Trusted Update List.
+  Mechanism to update information on the validity of signatures.)
 
-## Personas:
+## Personas
+
 - Publisher: User who builds and signs containers.
-    - Publisher Admin: In some scenarios a publisher will include a group of users (i.e. teams or enterprises). Admin users (i.e. security administrator) will be responsible for configuring roots, provide access to use or generate delegate keys, and make decisions for key revocation.
-    - Publisher Builder: In some scenarios a publisher will include a group of users (i.e. teams or enterprises). Builders (i.e. developers, build hosts) will be responsible for creating artifacts. 
-    - Publisher Signer: In some scenarios a publisher will include a group of users (i.e. teams or enterprises). Signers (i.e. developers, signing hosts) will be responsible for signing artifacts.
-- Deployer: User who deploys containers.
-    - Deployer Admin: In some scenarios a deployer will include a group of users (i.e. teams or enterprises). Admin users (i.e. security administrators) will be responsible for configuring deployment policies, including potentially a set of trusted roots or required signatures. 
-    - Deployer Operator: In some scenarios a publisher will include a group of users (i.e. teams or enterprises). Operators (i.e. developers, deployment hosts) will be responsible for pulling container images from registries, verifying their signatures, and then running them.
-- Repository Owner: In some scenarios a container may be stored in a repository that is managed by the repository owner. The repository may be public or private and could also be air-gapped.
+  - Publisher Admin:
+    In some scenarios a publisher will include a group of users (i.e. teams or enterprises).
+    Admin users (i.e. security administrator) will be responsible for configuring roots, provide access to use or generate delegate keys, and make decisions for key revocation.
+  - Publisher Builder:
+    In some scenarios a publisher will include a group of users (i.e. teams or enterprises).
+    Builders (i.e. developers, build hosts) will be responsible for creating artifacts.
+  - Publisher Signer:
+    In some scenarios a publisher will include a group of users (i.e. teams or enterprises).
+    Signers (i.e. developers, signing hosts) will be responsible for signing artifacts.
+  - Deployer:
+    User who deploys containers.
+  - Deployer Admin:
+    In some scenarios a deployer will include a group of users (i.e. teams or enterprises).
+    Admin users (i.e. security administrators) will be responsible for configuring deployment policies, including potentially a set of trusted roots or required signatures.
+  - Deployer Operator:
+    In some scenarios a publisher will include a group of users (i.e. teams or enterprises).
+    Operators (i.e. developers, deployment hosts) will be responsible for pulling container images from registries, verifying their signatures, and then running them.
+- Repository Owner:
+  In some scenarios a container may be stored in a repository that is managed by the repository owner.
+  The repository may be public or private and could also be air-gapped.
 
-## Definitions:
-- Root key: A self signed key used for the lowest designation of trust. Root keys can be created by developers, organizations, public/private CAs, and registry operators. The root key should be retrieved from a trusted source that can establish the authenticity of the creator's identity.
-- Signing key: A signing key is used to generate artifact signatures. A signing key should be signed with a root key or one of its intermediaries. The certificate chain with a signing key can be used to verify which root it belongs to. While a root key can be used as a signing key, this is not recommended as it creates a large blast radius and increases the risk of compromising a root key. 
-- Trust Policy: The trust policy defines whether to enable signature validation and which checks need to be run. An example trust policy:
-```
-    {
-        "trustPolicy": {
-            "signatureCheck": true,
-            "optionalChecks": {
-            	"signatureExpiry": true,
-            	"signatureRescinded": false
-            },
-            "trustStore": [
-            	"truststore.json",
-            	{
-            		"trustedRoots": [{
-            			"root": "test.crt"
-            		}]
-            	}
-            ],
-            "trustedArtifacts": []
-        }
+## Definitions
+
+- Root key:
+  A self signed key used for the lowest designation of trust.
+  Root keys can be created by developers, organizations, public/private CAs, and registry operators.
+  The root key should be retrieved from a trusted source that can establish the authenticity of the creator's identity.
+- Signing key:
+  A signing key is used to generate artifact signatures.
+  A signing key should be signed with a root key or one of its intermediaries.
+  The certificate chain with a signing key can be used to verify which root it belongs to.
+  While a root key can be used as a signing key, this is not recommended as it creates a large blast radius and increases the risk of compromising a root key.
+- Trust Policy:
+  The trust policy defines whether to enable signature validation and which checks need to be run.
+  An example trust policy:
+
+  ```json
+  {
+    "trustPolicy": {
+      "signatureCheck": true,
+      "optionalChecks": {
+      "signatureExpiry": true,
+      "signatureRescinded": false
+    },
+    "trustStore": {
+      "truststore.json": {
+        "trustedRoots": [
+          { "root": "test.crt" }
+        ]
+      }
+    },
+    "trustedArtifacts": []
     }
-```
-- Trust Store: The trust store defines the relationship between signing keys and artifacts that are used at validation time to determine whether to trust an artifact with a crytptographically valid signature. The trust store will relate a scope (any source, specific registry, specific repository, or specific target) with a certificate (for root key, intermediate, or signing key) or key repository (for automated key distribtuion). It is not recommended to use a signing key as this will cause signature validation to fail if the signing key is rotated. An example trustStore where the first root is trusted for artifacts from any registry and the second root is only trusted for artifacts from "registry.wabbit-networks.io" :
-```
-    {
-    	"trustedRoots": [{
- 	    		"root": "-----BEGIN CERTIFICATE-----examplecertificate-----END CERTIFICATE-----"
- 	    	},
- 	    	{
- 	    		"root": "-----BEGIN CERTIFICATE-----examplecertificate-----END CERTIFICATE-----",
- 	    		"scope": "registry.wabbit-networks.io"
- 	    	}
- 	    ]
-    }
-```
+  }
+  ```
+
+- Trust Store:
+  The trust store defines the relationship between signing keys and artifacts that are used at validation time to determine whether to trust an artifact with a crytptographically valid signature.
+  The trust store will relate a scope (any source, specific registry, specific repository, or specific target) with a certificate (for root key, intermediate, or signing key) or key repository (for automated key distribtuion).
+  It is not recommended to use a signing key as this will cause signature validation to fail if the signing key is rotated.
+  An example trustStore where the first root is trusted for artifacts from any registry and the second root is only trusted for artifacts from "registry.wabbit-networks.io" :
+
+  ```json
+  {
+    "trustedRoots": [
+      {
+        "root": "-----BEGIN CERTIFICATE-----examplecertificate-----END CERTIFICATE-----"
+      },
+      {
+        "root": "-----BEGIN CERTIFICATE-----examplecertificate-----END CERTIFICATE-----",
+        "scope": "registry.wabbit-networks.io"
+      }
+    ]
+  }
+  ```
+
 - Trust Store Key Information: The key information configured in the trust store will be cryptographically verifiable and contain:
-    - Public Key: Will be used to verify signed artifacts.
-    - Signed Identity: Identity of creator of the signing key.
-    - (Optional) Issuer: If the key is an intermediate this will describe the owner of the root.
-    - (Optional) Mechanism to check whether signatures generated with the signing key have been rescinded.
+  - Public Key: Will be used to verify signed artifacts.
+  - Signed Identity: Identity of creator of the signing key.
+  - (Optional) Issuer: If the key is an intermediate this will describe the owner of the root.
+  - (Optional) Mechanism to check whether signatures generated with the signing key have been rescinded.
 
 ## Requirements
-- Signing an artifact MUST NOT require the publisher to perform additional actions with a registry/repository or registry operator. Uploading a signature MAY require additional actions.
+
+- Signing an artifact MUST NOT require the publisher to perform additional actions with a registry/repository or registry operator.
+  Uploading a signature MAY require additional actions.
 - Retrieving a signature MUST NOT require the deployer to perform additional actions with a registry/repository or registry operator beyond those required to pull an unsigned artifact.
 - Artifact integrity, source, and signature expiry MUST be verifiable from the signature AND NOT require additional calls to the registry/repository.
 - Signature allow list/deny list MAY require additional calls that will be defined in a separate document.
 - Copying an artifact from one repository to another SHOULD NOT invalidate the signature on the artifact.
 - Publishers SHOULD be able to sign with keys stored on their local machines, secure tokens, Hardware Security Modules (HSMs), or cloud based Key Management Services.
 - Publishers SHOULD be able to generate multiple signatures for a single artifact.
-- Publisher admins MUST have a mechanism to revoke signatures to indicate they are no longer trusted. 
+- Publisher admins MUST have a mechanism to revoke signatures to indicate they are no longer trusted.
 - Trust stores MUST be configurable by the deployer admin.
 - Deployer admins MUST be able to configure trusted entities for individual repositories and targets.
 - Deployers MUST be able to validate signatures on any version of an artifact including whether they have been revoked by the publisher.
-- Signature validation MUST be enforceable in air-gapped environments. 
+- Signature validation MUST be enforceable in air-gapped environments.
 
 ## Prototype Stages
-1. Signature generation for each of the key storage scenarios. A succesful prototype should enable signing with keys on each of the following: local host, secure tokens, Hardware Security Modules (HSMs), and cloud based Key Management Services.
-2. Trust store configuration and signature source validation in runtime environments. A succesful prototype should enable configuring a trust store in a runtime environment. The prototype should validate signatures from a trusted source and reject signatures from a source that is not listed. The prototype will not check for other aspects of signature validity (expiry/revocation).
-3. Key rotation. A succesful prototype should meet all requirements from the key rotation document.
-4. Signature/Key Expiration. A succesful prototype should meet all requirements from the signature/key expiry document.
-5. Signature allowlist/denylist. A succesful prototype should meet all requirements from the signatur allowlist/denylist document.
+
+1. Signature generation for each of the key storage scenarios.
+   A succesful prototype should enable signing with keys on each of the following: local host, secure tokens, Hardware Security Modules (HSMs), and cloud based Key Management Services.
+1. Trust store configuration and signature source validation in runtime environments.
+   A succesful prototype should enable configuring a trust store in a runtime environment.
+   The prototype should validate signatures from a trusted source and reject signatures from a source that is not listed.
+   The prototype will not check for other aspects of signature validity (expiry/revocation).
+1. Key rotation.
+   A succesful prototype should meet all requirements from the key rotation document.
+1. Signature/Key Expiration.
+   A succesful prototype should meet all requirements from the signature/key expiry document.
+1. Signature allowlist/denylist.
+   A succesful prototype should meet all requirements from the signatur allowlist/denylist document.

--- a/requirements.md
+++ b/requirements.md
@@ -67,7 +67,8 @@ As we identify the requirements and constraints, a number of key contributors wi
 
 Regular conversations for Notary v2 occur on the [Cloud Native Computing Slack](https://app.slack.com/client/T08PSQ7BQ/CQUH8U287?) channel.
 
-Weekly meetings occur each Monday. Please see the [CNCF Calendar](https://www.cncf.io/community/calendar/) for details.
+Weekly meetings occur each Monday.
+Please see the [CNCF Calendar](https://www.cncf.io/community/calendar/) for details.
 
 Meeting notes are captured on [hackmd.io](https://hackmd.io/_vrqBGAOSUC_VWvFzWruZw).
 

--- a/scenarios.md
+++ b/scenarios.md
@@ -2,46 +2,51 @@
 
 As containers and cloud native artifacts become the common unit of deployment, users want to know the artifacts in their environments are authentic and unmodified.
 
-These Notary v2 scenarios define end-to-end scenarios for signing artifacts in a generalized way, storing and moving them between OCI compliant registries, validating them with various artifact hosts and tooling. Notary v2 focuses on the signing of content, enabling e2e workflows, without specifying what those workflows must be.
+These Notary v2 scenarios define end-to-end scenarios for signing artifacts in a generalized way, storing and moving them between OCI compliant registries, validating them with various artifact hosts and tooling.
+Notary v2 focuses on the signing of content, enabling e2e workflows, without specifying what those workflows must be.
 
 By developing a generalized solution, artifact authors may develop their unique artifact types, allowing them to leverage Notary for signing and OCI Compliant registries for distribution.
 
 ## Scenarios
 
-Notary v2 aims to solve the core issue of trusting content within, and across registries. There are many elements of an end to end scenario that are not implemented by Notary v2, rather enabled because the content is verifiable.
+Notary v2 aims to solve the core issue of trusting content within, and across registries.
+There are many elements of an end to end scenario that are not implemented by Notary v2, rather enabled because the content is verifiable.
 
 ### Scenario #0: Build, Publish, Consume, Enforce Policy, Deploy
 
-To put Notary v2 in context, the following end-to-end scenario is outlined. The blue elements are the scope of Notary v2, with the other elements providing generic references to other projects or products that demonstrate how Notary v2 may be utilized.
+To put Notary v2 in context, the following end-to-end scenario is outlined.
+The blue elements are the scope of Notary v2, with the other elements providing generic references to other projects or products that demonstrate how Notary v2 may be utilized.
 
 ![Notary e2e Scenarios](./media/notary-e2e-scenarios.svg)
 
-In a world of consuming public software, we must account for content that's acquired from a public source, copied into a trusted environment, then deployed. In this scenario, the consumer is not re-building or adding additional content. However, they do wish to add attestations to the validity of the content.
+In a world of consuming public software, we must account for content that's acquired from a public source, copied into a trusted environment, then deployed.
+In this scenario, the consumer is not re-building or adding additional content.
+However, they do wish to add attestations to the validity of the content.
 
 1. The Wabbit Networks company builds their `net-monitor` software.
-      * As a result of the build, they produce an [OCI Image][oci-image], a Software Bill of Materials (`SBoM`) and to comply with gpl licensing, produce another artifact which contains the source (`src`) to all the gpl licensed projects.  
-      * The `SBoM` and `src` artifacts are created as reference types to the image, creating a graph of artifacts.
-      * Each of the artifacts are signed with the Notary v2 wabbit-networks key.
-2. The Wabbit Networks signed contents are pushed to a public OCI compliant registry.
-      * Docker can provide an additional Docker hub signature providing an extra level of certification confidence.
-3. ACME Rockets consumes the `net-monitor` software, importing the referenced artifacts into their private registry.
-      * ACME Rockets verifies the content, including additional scanning and functional testing for their environment.
-      * The SBoM is trusted as they trust artifacts signed by wabbit-networks, or possibly defer trust to the Docker Hub certification signature.
-      * They denote verification of the SBoM and scanning with an ACME Rockets signature.
-      * A `deploy` artifact, referencing a specific configuration definition, may also be signed and saved, providing a historical record of what was deployed.
-4. The ACME Rockets environment may enforce various policies prior to deployment:
-      * Evaluating the content in the `SBoM` for policies on specific packages.
-      * ACME Rockets only allows content signed by ACME Rockets to be deployed, and only from the registry identified in the ACME Rockets signature.
-      * Once validated, the `src` and `SBoM` are no longer needed for deployment allowing the `image` to be deployed separately with it's own signature.
-5. Once the policy manager completes its validation (k8s ingress controller with OPA), the deployment to the hosting environment is initiated.
-      * ACME Rockets runs in an air-gapped environment, requiring all key access to be resolved within their environment.
+      - As a result of the build, they produce an [OCI Image][oci-image], a Software Bill of Materials (`SBoM`) and to comply with gpl licensing, produce another artifact which contains the source (`src`) to all the gpl licensed projects.
+      - The `SBoM` and `src` artifacts are created as reference types to the image, creating a graph of artifacts.
+      - Each of the artifacts are signed with the Notary v2 wabbit-networks key.
+1. The Wabbit Networks signed contents are pushed to a public OCI compliant registry.
+      - Docker can provide an additional Docker hub signature providing an extra level of certification confidence.
+1. ACME Rockets consumes the `net-monitor` software, importing the referenced artifacts into their private registry.
+      - ACME Rockets verifies the content, including additional scanning and functional testing for their environment.
+      - The SBoM is trusted as they trust artifacts signed by wabbit-networks, or possibly defer trust to the Docker Hub certification signature.
+      - They denote verification of the SBoM and scanning with an ACME Rockets signature.
+      - A `deploy` artifact, referencing a specific configuration definition, may also be signed and saved, providing a historical record of what was deployed.
+1. The ACME Rockets environment may enforce various policies prior to deployment:
+      - Evaluating the content in the `SBoM` for policies on specific packages.
+      - ACME Rockets only allows content signed by ACME Rockets to be deployed, and only from the registry identified in the ACME Rockets signature.
+      - Once validated, the `src` and `SBoM` are no longer needed for deployment allowing the `image` to be deployed separately with it's own signature.
+1. Once the policy manager completes its validation (k8s ingress controller with OPA), the deployment to the hosting environment is initiated.
+      - ACME Rockets runs in an air-gapped environment, requiring all key access to be resolved within their environment.
 
 **Implications of this requirement:**
 
-* Signatures can be placed on any type of [artifact](artifacts-repo) stored in an OCI compliant registry using an [OCI Manifest][oci-manifest]
-* Signatures can be persisted as references to the [OCI Manifest][oci-manifest], allowing a entity to define a collection of artifacts.
-* Signatures and their public keys can be moved within, and across OCI compliant registries which support Notary v2.
-* Because content is trusted, an ecosystem of other projects and products can leverage information in various formats.
+- Signatures can be placed on any type of [artifact](artifacts-repo) stored in an OCI compliant registry using an [OCI Manifest][oci-manifest]
+- Signatures can be persisted as references to the [OCI Manifest][oci-manifest], allowing a entity to define a collection of artifacts.
+- Signatures and their public keys can be moved within, and across OCI compliant registries which support Notary v2.
+- Because content is trusted, an ecosystem of other projects and products can leverage information in various formats.
 
 ### Scenario #1: Local Build, Sign, Validate
 
@@ -55,13 +60,16 @@ Prior to committing any code, a developer can test the: "build, sign, validate s
 
 **Implications of this requirement:**
 
-* The developer has access to signing keys. How they get the keys will be part of a usability or design spec.
-* The local environment has a policy by which it states the set of keys it accepts.
-* The signing and validation of artifacts does not require a registry. The local host can validate the signature using the public keys it accepts.
-* The key used for validation may be hosted in a registry, or other accessible location.
-* The lack of a registry name does not infer docker.io as a default registry.
-* Signing is performed on the artifacts that may be pushed to a registry.
-* The verification of the signature can occur without additional transformation or computation. If the artifact is expected to be compressed, the signature will be performed on the compressed artifact rather than the uncompressed content.
+- The developer has access to signing keys.
+  How they get the keys will be part of a usability or design spec.
+- The local environment has a policy by which it states the set of keys it accepts.
+- The signing and validation of artifacts does not require a registry.
+  The local host can validate the signature using the public keys it accepts.
+- The key used for validation may be hosted in a registry, or other accessible location.
+- The lack of a registry name does not infer docker.io as a default registry.
+- Signing is performed on the artifacts that may be pushed to a registry.
+- The verification of the signature can occur without additional transformation or computation.
+  If the artifact is expected to be compressed, the signature will be performed on the compressed artifact rather than the uncompressed content.
 
 ### Scenario #2: Sign, Rename, Push, Validate in Dev
 
@@ -77,11 +85,14 @@ Once the developer has locally validated the build, sign, validate scenario, the
 
 **Implications of this requirement:**
 
-* Signatures are verified based on manifest of the referenced `artifact:tag`.
-* The artifact can be renamed from the unique build id `net-monitor:abc123` to a product versioned tag `wabbitnetworks.example.com/networking/net-monitor:1.0` without invalidating the signature.
-* Users may reference the `sha256` digest directly, or the `artifact:tag`. While tag locking is not part of the [OCI Distribution Spec][oci-distribution], various registries support this capability, allowing users to reference human readable tags, as opposed to long digests. Either reference is supported with Notary v2, however it's the unique manifest that is signed.
-* Notary v2 supports a pattern for signing any type of artifact, from OCI Images, Helm Charts, Singularity to yet unknown types.
-* Orchestrators may require signatures, but not enforce specific specific signatures. This enables a host to understand what content is deployed, without having to manage specific keys.
+- Signatures are verified based on manifest of the referenced `artifact:tag`.
+- The artifact can be renamed from the unique build id `net-monitor:abc123` to a product versioned tag `wabbitnetworks.example.com/networking/net-monitor:1.0` without invalidating the signature.
+- Users may reference the `sha256` digest directly, or the `artifact:tag`.
+  While tag locking is not part of the [OCI Distribution Spec][oci-distribution], various registries support this capability, allowing users to reference human readable tags, as opposed to long digests.
+  Either reference is supported with Notary v2, however it's the unique manifest that is signed.
+- Notary v2 supports a pattern for signing any type of artifact, from OCI Images, Helm Charts, Singularity to yet unknown types.
+- Orchestrators may require signatures, but not enforce specific specific signatures.
+  This enables a host to understand what content is deployed, without having to manage specific keys.
 
 ### Scenario #3: Automate Build, Sign, Push, Deploy to Prod, Verify
 
@@ -92,74 +103,81 @@ A CI system is triggered by a git commit. The system builds the artifacts, signs
   **image**: `wabbitnetworks.example.com/networking/net-monitor:1.0-alpine`
   **deployment chart**: `wabbitnetworks.example.com/networking/net-monitor:1.0-deploy`
 1. The CI system signs each artifact with private keys.
-2. The CI system creates reference between the signatures and the image and deployment chart:  
+1. The CI system creates reference between the signatures and the image and deployment chart:  
   `wabbitnetworks.example.com/networking/net-monitor:1.0`
-3. The graph of artifacts and references are pushed to a registry:  
+1. The graph of artifacts and references are pushed to a registry:  
   `$ oci-tool push wabbitnetworks.example.com/networking/net-monitor:1.0-alpine`  
   `$ deploy-tool push wabbitnetworks.example.com/networking/net-monitor:1.0-deploy`  
   `$ oci-tool push wabbitnetworks.example.com/networking/net-monitor:1.0`
 1. The artifacts are deployed to a production orchestrator.
-1. The orchestrator verifies the artifacts are signed by a set of specifically trusted keys. Unsigned artifacts, or artifacts signed by non-trusted keys are rejected.
+1. The orchestrator verifies the artifacts are signed by a set of specifically trusted keys.
+  Unsigned artifacts, or artifacts signed by non-trusted keys are rejected.
 
 **Implications of this requirement:**
 
-* Keys for signing are securely retrieved by build systems that create & destroy the environment each time or alternatively the signing is offloaded to an external system, without exposing the private key to the CI system.
-* A specific set of keys may be required to pass validation.
+- Keys for signing are securely retrieved by build systems that create & destroy the environment each time or alternatively the signing is offloaded to an external system, without exposing the private key to the CI system.
+- A specific set of keys may be required to pass validation.
 
 ### Scenario #4: Promote Artifacts Within a Registry
 
 A CI/CD system promotes validated artifacts from a dev repository to production repositories.
 
 1. A CI/CD solution responds to a git commit notification, cloning, building, signing and pushing the artifacts to a development repo within their registry.
-1. As the CI/CD solution runs functional tests, determining the artifacts are ready for production, the artifacts are moved from one repo to another.  
+1. As the CI/CD solution runs functional tests, determining the artifacts are ready for production, the artifacts are moved from one repo to another.
   `$ oci-tool tag myregistry.example.com/dev/alpha-team/web:1abc myregistry.example.com/prod/web:1abc`
 
 ### Scenario #4.1: Archive Artifacts Within a Registry
 
-Once artifacts are no longer running in production, they are archived for a period of months. They are moved out of the production registry or repo as they must be maintained in the state they were run for compliance requirements.
+Once artifacts are no longer running in production, they are archived for a period of months.
+They are moved out of the production registry or repo as they must be maintained in the state they were run for compliance requirements.
 
 1. A lifecycle management solution moves artifacts from production repositories to archived repositories and/or registries.
 
 **Implications of this requirement:**
 
-* Changing the path to an artifact maintains artifact signatures.
-* Artifact copy, or movement to a different repository within the same registry maintains the signatures.
+- Changing the path to an artifact maintains artifact signatures.
+- Artifact copy, or movement to a different repository within the same registry maintains the signatures.
 
 ### Scenario #5: Validate Artifact Signatures Within Restricted Networks
 
-ACME Rockets runs secure air-gapped production environments, limiting all external network traffic. To assure the wabbit-networks network monitor software has valid signatures, it must be possible to verify the software without access to wabbit-networks systems.
+ACME Rockets runs secure air-gapped production environments, limiting all external network traffic.
+To assure the wabbit-networks network monitor software has valid signatures, it must be possible to verify the software without access to wabbit-networks systems.
 
 1. ACME Rockets acquires network monitoring software, copying it to their firewall protected production environment.
 1. As part of the artifact copy, ACME Rockets copies all other resources that are required for successful signature validation.
 
 **Implications of this requirement:**
 
-* In this scenario, the wabbit-networks signature must be validated within the ACME Rockets network. How this is done is open for design. However, the requirement states the signature must be validated without external access.
-* When the artifact is copied to the private/network restricted registry, the signature may need to be copied, and is assumed to be trusted if available in the trusted server within the private network.
-* How ACME Rockets would copy the signatures is part of the key management scenarios.
-* How ACME Rockets handles revoked keys is also part of the key management scenarios.
+- In this scenario, the wabbit-networks signature must be validated within the ACME Rockets network.
+  How this is done is open for design.
+  However, the requirement states the signature must be validated without external access.
+- When the artifact is copied to the private/network restricted registry, the signature may need to be copied, and is assumed to be trusted if available in the trusted server within the private network.
+- How ACME Rockets would copy the signatures is part of the key management scenarios.
+- How ACME Rockets handles revoked keys is also part of the key management scenarios.
 
 ### Scenario #6: Multiple Signatures
 
 Customers may require multiple signatures for the following scenarios:
 
-* Validate the artifact is the same as what the vendor provided.
-* Secondarily sign the artifact by the consuming company, attesting to its validity within their production environment.
-* Signatures represent validations through different dev, staging, production environments.
-* Crypto algorithms may be deprecated, requiring new signatures to be added, while maintaining a grace period of both signatures.
-* Dev environments support any signature, while integration and production environments require acme-rockets-prod signatures.
+- Validate the artifact is the same as what the vendor provided.
+- Secondarily sign the artifact by the consuming company, attesting to its validity within their production environment.
+- Signatures represent validations through different dev, staging, production environments.
+- Crypto algorithms may be deprecated, requiring new signatures to be added, while maintaining a grace period of both signatures.
+- Dev environments support any signature, while integration and production environments require acme-rockets-prod signatures.
 
 #### Scenario #6.1: Dev and Prod Keys
 
 1. A CI/CD solution builds, signs, pushes and deploys a collection of artifacts to a staging environment.
 1. Once integrations tests are completed, the artifacts are signed with a production signature, copying them to a production registry or production set of repositories.
-    * `myregistry.example.com/dev/alpha-team/web:1abc` - signed with the **alpha-team dev** key
-    * `myregistry.example.com/prod/web:1abc` - signed with the **prod** key
+    - `myregistry.example.com/dev/alpha-team/web:1abc` - signed with the **alpha-team dev** key
+    - `myregistry.example.com/prod/web:1abc` - signed with the **prod** key
 1. The integration and production orchestrators validate the artifacts are signed with production keys.
 
 #### Scenario #6.2: Approved Vendor/Project Artifacts
 
-A deployment requires a mydb image. The mydb image is routinely updated for security vulnerabilities. ACME Rockets references stable version tags (`mydb:1.0`), assuring they get newly patched builds, but they must verify each new version to be compatible with their environment.
+A deployment requires a mydb image.
+The mydb image is routinely updated for security vulnerabilities.
+ACME Rockets references stable version tags (`mydb:1.0`), assuring they get newly patched builds, but they must verify each new version to be compatible with their environment.
 
 1. The `mydb:1.0` image is acquired from a public registry, imported into private integration registries.
 1. Functional testing is run in the integration environment, verifying the patched `mydb:1.0` image is compatible.
@@ -170,14 +188,15 @@ A deployment requires a mydb image. The mydb image is routinely updated for secu
 
 **Implications of this requirement:**
 
-* Multiple signatures, including signatures from multiple sources can be associated with a specific artifact.
-* Original signatures are maintained, even if the artifact is re-tagged.
+- Multiple signatures, including signatures from multiple sources can be associated with a specific artifact.
+- Original signatures are maintained, even if the artifact is re-tagged.
 
 ### Scenario #7: Repository Compromise - Non Signed Content
 
 An attacker gains access to a registry and/or repository within a registry, pushing content that is suspect.
 
-In this scenario, the attacker didn't have the private keys to sign the new content. They pushed unsigned content to existing tags.
+In this scenario, the attacker didn't have the private keys to sign the new content.
+They pushed unsigned content to existing tags.
 
 1. An attacker gains access to the credentials, allowing them to push new content.
 1. The attacker pushes an artifact with compatible behavior, with an additional exploit.
@@ -191,14 +210,19 @@ In this scenario, the attacker didn't have the private keys to sign the new cont
 
 1. The potential damage/risk to consumers must be limited.
 1. There must be a secure way for users to recover to a known, secure state and verify this has occurred even in the face of an attacker that can act as a man-in-the-middle on the network.
-1. How a registry implements the rollback to the previously secured state is a differentiating capability. The scenario simply calls out a compromise that must be discoverable through forensic logging of who, when and what was pushed. The logged updates must include previous digests that represented updated tags allowing a registry, or external tools, to reset its original state.
-1. A registry may choose to make repos, or the entire registry, restricted to pushing only signed content, and potentially only signed content with one or more keys. Notary v2 doesn't require this capability, rather highlights the scenario for registry operators to innovate means to secure from this scenario.
+1. How a registry implements the rollback to the previously secured state is a differentiating capability.
+   The scenario simply calls out a compromise that must be discoverable through forensic logging of who, when and what was pushed.
+   The logged updates must include previous digests that represented updated tags allowing a registry, or external tools, to reset its original state.
+1. A registry may choose to make repos, or the entire registry, restricted to pushing only signed content, and potentially only signed content with one or more keys.
+   Notary v2 doesn't require this capability, rather highlights the scenario for registry operators to innovate means to secure from this scenario.
 
 #### Scenario #7.1: Repository Compromise - Mutable Tags Modified
 
-An attacker gains access to a registry and/or repository within a registry, changing the tag reference to a different digest. This different digest may be either a less-secure image (downgrading from a hardened image to one with more features that may be attacked), or a replay to an older vulnerable version of the same tag.
+An attacker gains access to a registry and/or repository within a registry, changing the tag reference to a different digest.
+This different digest may be either a less-secure image (downgrading from a hardened image to one with more features that may be attacked), or a replay to an older vulnerable version of the same tag.
 
-In this scenario, the attacker didn't have the private keys to sign the new content. Instead, they modified tags to point to previously signed content and either reused the signatures already on the registry for the digest, or pushed stale signatures from a previous state of the registry.
+In this scenario, the attacker didn't have the private keys to sign the new content.
+Instead, they modified tags to point to previously signed content and either reused the signatures already on the registry for the digest, or pushed stale signatures from a previous state of the registry.
 
 1. An attacker gains access to the credentials, allowing them to push new content.
 1. The attacker pushes an old artifact with compatible behavior, either with an old exploit or additional capabilities that exposes vulnerabilities.
@@ -235,7 +259,8 @@ A developer accidentally discloses the private key they use to certify their sof
 
 ### Scenario #9: A Crypto Algorithm Is Deprecated
 
-A weakness is discovered in a widely used cryptographic algorithm and a decision is made to deprecate its use in favor of one or more newer algorithms. It should be possible to migrate smoothly to the new algorithm(s), despite the fact that developers will adopt the new signing algorithm(s) piecemeal.
+A weakness is discovered in a widely used cryptographic algorithm and a decision is made to deprecate its use in favor of one or more newer algorithms.
+It should be possible to migrate smoothly to the new algorithm(s), despite the fact that developers will adopt the new signing algorithm(s) piecemeal.
 
 1. A build system has been using version **n** of a crypto library for the last 3 years, signing thousands of artifacts.
 1. A new version is available and developers migrate to the new library.
@@ -252,18 +277,22 @@ A weakness is discovered in a widely used cryptographic algorithm and a decision
 
 ### Scenario #10: Specifying a trusted key
 
-A user may want to trust an artifact only if it is signed by a specific key. Maybe this is an internally created artifact with a known signing key. This key may be distributed using a trusted third party mechanism.
+A user may want to trust an artifact only if it is signed by a specific key.
+Maybe this is an internally created artifact with a known signing key.
+This key may be distributed using a trusted third party mechanism.
 
 1. The user obtains a trusted key for a particular artifact.
 1. The user downloads and verifies the artifact using Notary v2 and their known key.
 
-**Implications of this requirement**
+**Implications of this requirement:**
 
 1. Users must be allowed to configure specific trusted keys for specific artifacts or collections of artifacts.
 
 ### Scenario #11: Revoking a Signature
 
-A signer determines that a signed artifact is no longer trusted. This could be a result of accidentally signing the wrong artifact, or a CVE discovered in the image and patched in a newer release. It should be possible for the signer to revoke the trust in that vulnerable artifact.
+A signer determines that a signed artifact is no longer trusted.
+This could be a result of accidentally signing the wrong artifact, or a CVE discovered in the image and patched in a newer release.
+It should be possible for the signer to revoke the trust in that vulnerable artifact.
 
 1. A CVE is discovered in a signed artifact.
 1. The signature on the vulnerable artifact is revoked.
@@ -271,7 +300,8 @@ A signer determines that a signed artifact is no longer trusted. This could be a
 
 **Implications of this requirement:**
 
-1. Users that wish to still run artifacts that have their signatures revoked may need to take additional steps. Possible resolutions include configuring their client to ignore the revocation failure, disabling verification on the vulnerable artifact, or resigning the artifacts with a key they control and trust.
+1. Users that wish to still run artifacts that have their signatures revoked may need to take additional steps.
+   Possible resolutions include configuring their client to ignore the revocation failure, disabling verification on the vulnerable artifact, or resigning the artifacts with a key they control and trust.
 1. Attackers attempting to replay revoked signatures should be detected by the verification.
 1. Revoking the signature for a single artifact should not require revoking the signer's key or signatures for all other artifacts by the same signer.
 
@@ -282,15 +312,15 @@ If a user does not have a specific key for a given artifact, verified using a th
 1. The user determines the trusted key(s) for a specific artifact using delegations from a trusted root.
 1. The user downloads and verifies an artifact using Notary v2 and the trusted key(s) discovered in the previous step.
 
-**Implications of this requirement**
+**Implications of this requirement:**
 
 1. Users must be able to to access a chain of trust that links the signing key for a particular artifact to a trusted root.
 1. Users must be able to configure roots of trust.
 
 ## Open Discussions
 
-* What is the relationship between a signature, an artifact and a registry?
-* Can signature validation be dependent on an external entity?
+- What is the relationship between a signature, an artifact and a registry?
+- Can signature validation be dependent on an external entity?
 
 [acr]:              https://aka.ms/acr/artifacts
 [artifacts-repo]:   https://github.com/opencontainers/artifacts

--- a/signature-specification.md
+++ b/signature-specification.md
@@ -19,8 +19,11 @@ The signature manifest has an artifact type that specifies it's a Notary V2 sign
 - **`blobs`** (*array of objects*): This REQUIRED property contains collection of only one [artifact descriptor](https://github.com/oras-project/artifacts-spec/blob/main/descriptor.md) referencing signature envelope.
   - **`mediaType`** (*string*): This REQUIRED property contains media type of signature envelope blob. The supported value is `application/jose+json`
 - **`subject`** (*descriptor*): A REQUIRED artifact descriptor referencing the signed manifest, including, but not limited to image manifest, image index, oras-artifact manifest.
-- **`annotations`** (*string-string map*): This REQUIRED property contains metadata for the artifact manifest. It is being used to store information about the signature. Keys using the `org.cncf.notary` namespace are reserved for use in Notary and MUST NOT be used by other specifications.
-  - **`org.cncf.notary.x509certs.fingerprint.sha256`**: A REQUIRED annotation whose value contains the list of SHA-256 fingerprint of signing certificate and certificate chain used for signature generation. The list of fingerprints is present as a JSON array string.
+- **`annotations`** (*string-string map*): This REQUIRED property contains metadata for the artifact manifest.
+  It is being used to store information about the signature.
+  Keys using the `org.cncf.notary` namespace are reserved for use in Notary and MUST NOT be used by other specifications.
+  - **`org.cncf.notary.x509certs.fingerprint.sha256`**: A REQUIRED annotation whose value contains the list of SHA-256 fingerprint of signing certificate and certificate chain used for signature generation.
+    The list of fingerprints is present as a JSON array string.
 
 ```json
 {
@@ -46,7 +49,9 @@ The signature manifest has an artifact type that specifies it's a Notary V2 sign
 ### Signature Discovery
 
 The client should be able to discover all the signatures belonging to an artifact (such as image manifest) by using [ORAS Manifest Referrers API](https://github.com/oras-project/artifacts-spec/blob/main/manifest-referrers-api.md).
-ORAS Manifest Referrers API returns a paginated list of all artifacts belonging to a target artifact (such as container images, SBoMs). The implementation can filter Notary signature artifacts by either using ORAS Manifest Referrers API or using custom logic on the client. Each Notary signature artifact refers to a signature envelope blob.  
+ORAS Manifest Referrers API returns a paginated list of all artifacts belonging to a target artifact (such as container images, SBoMs).
+The implementation can filter Notary signature artifacts by either using ORAS Manifest Referrers API or using custom logic on the client.
+Each Notary signature artifact refers to a signature envelope blob.
 
 ### Signature Filtering
 
@@ -55,7 +60,8 @@ The Notary v2 signature artifact's `org.cncf.notary.x509certs.fingerprint.sha256
 
 ## Signature Envelope
 
-The Signature Envelope is a standard data structure for creating a signed message. A signature envelope consists of the following components:
+The Signature Envelope is a standard data structure for creating a signed message.
+A signature envelope consists of the following components:
 
 - Payload `m`: The data that is integrity protected - e.g. descriptor of the artifact being signed.
 - Signed attributes `v`: The signature metadata that is integrity protected - e.g. signature expiration time, signing time, etc.
@@ -71,8 +77,11 @@ Notary v2 supports [JWS JSON Serialization](https://datatracker.ietf.org/doc/htm
 Notary v2 requires Payload to be the content **descriptor** of the subject manifest that is being signed.
 
 1. Descriptor MUST contain `mediaType`, `digest`, `size` fields.
-2. Descriptor MAY contain `annotations` and if present it MUST follow the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules). In Notary v2 annotations are being used to store signed attributes. The annotations key prefix for Notary v2 use is not yet finalized. See [issues-106](https://github.com/notaryproject/notaryproject/issues/106).
-3. Descriptor MAY contain `artifactType` field for artifact manifests, or the `config.mediaType` for `oci.image` based manifests.
+1. Descriptor MAY contain `annotations` and if present it MUST follow the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules).
+   In Notary v2 annotations are being used to store signed attributes.
+   The annotations key prefix for Notary v2 use is not yet finalized.
+   See [issues-106](https://github.com/notaryproject/notaryproject/issues/106).
+1. Descriptor MAY contain `artifactType` field for artifact manifests, or the `config.mediaType` for `oci.image` based manifests.
 
 Examples:
 
@@ -96,13 +105,18 @@ Examples:
 
 Notary v2 requires the signature envelope to support the following signed attributes:
 
-- **Creation time**: The time at which the signature was generated. Its value should be numeric representing the number of seconds (not milliseconds) since Epoch.
-- **Expiration time**: The time after which signature shouldn't be considered valid. Its value should be numeric representing the number of seconds since Epoch. This is an OPTIONAL attribute.
+- **Creation time**: The time at which the signature was generated.
+  Its value should be numeric representing the number of seconds (not milliseconds) since Epoch.
+- **Expiration time**: The time after which signature shouldn't be considered valid.
+  Its value should be numeric representing the number of seconds since Epoch.
+  This is an OPTIONAL attribute.
 
 ### Unsigned Attributes
 
 - **Certificates**: The ordered collection of X.509 certificates with a signing certificate as the first entry.
-- **Timestamp**:  The time stamp token generated for a given signature. Only [RFC3161](https://datatracker.ietf.org/doc/html/rfc3161#section-2.4.2) compliant *TimeStampToken* are supported. This is an OPTIONAL attribute.
+- **Timestamp**:  The time stamp token generated for a given signature.
+  Only [RFC3161](https://datatracker.ietf.org/doc/html/rfc3161#section-2.4.2) compliant *TimeStampToken* are supported.
+  This is an OPTIONAL attribute.
 
 ### Supported Signature Envelopes
 
@@ -115,7 +129,8 @@ Unless explicitly specified as OPTIONAL, all fields are required.
 Also, there shouldn’t be any additional fields other than ones specified in JWSPayload, ProtectedHeader, and UnprotectedHeader.
 
 **JWSPayload a.k.a. Claims**:
-Notary v2 is using one private claim (`notary`) and two public claims (`iat` and `exp`). An example of the claim is described below
+Notary v2 is using one private claim (`notary`) and two public claims (`iat` and `exp`).
+An example of the claim is described below
 
 ```json
 {
@@ -136,7 +151,8 @@ Notary v2 is using one private claim (`notary`) and two public claims (`iat` and
 
 The payload contains the subject manifest and other attributes that have to be integrity protected.
 
-- **`subject`**(*descriptor*): A REQUIRED top-level node consisting of the manifest that needs to be integrity protected. Please refer [Payload](#payload) section for more details.
+- **`subject`**(*descriptor*): A REQUIRED top-level node consisting of the manifest that needs to be integrity protected.
+  Please refer [Payload](#payload) section for more details.
 - **`iat`**(*number*): The REQUIRED property Issued-at(`iat`) identifies the time at which the signature was issued.
 - **`exp`**(*number*): This OPTIONAL property contains the expiration time on or after which the signature must not be considered valid.
 
@@ -152,9 +168,13 @@ To leverage JWS claims validation functionality already provided by libraries, w
 }
 ```
 
-- **`alg`**(*string*): This REQUIRED property defines which algorithm was used to generate the signature. JWS needs an algorithm(`alg`) to be present in the header, so we have added it as a protected header.
-- **`cty`**(*string*): The REQUIRED property content-type(cty) is used to declare the media type of the secured content(the payload). This will be used to version different variations of JWS signature. The supported value is `application/vnd.cncf.notary.v2.jws.v1`.
-- **`crit`**(*array of strings*): This REQUIRED property lists the headers that implementation MUST understand and process. The value MUST be `["cty"]`.
+- **`alg`**(*string*): This REQUIRED property defines which algorithm was used to generate the signature.
+  JWS needs an algorithm(`alg`) to be present in the header, so we have added it as a protected header.
+- **`cty`**(*string*): The REQUIRED property content-type(cty) is used to declare the media type of the secured content(the payload).
+  This will be used to version different variations of JWS signature.
+  The supported value is `application/vnd.cncf.notary.v2.jws.v1`.
+- **`crit`**(*array of strings*): This REQUIRED property lists the headers that implementation MUST understand and process.
+  The value MUST be `["cty"]`.
 
 **UnprotectedHeaders**: Notary v2 supports only two unprotected headers: timestamp and x5c.
 
@@ -165,17 +185,26 @@ To leverage JWS claims validation functionality already provided by libraries, w
 }
 ```
 
-- **`timestamp`** (*string*): This OPTIONAL property is used to store time stamp token. Only [RFC3161]([rfc3161](https://datatracker.ietf.org/doc/html/rfc3161#section-2.4.2)) compliant TimeStampToken are supported.
-- **`x5c`** (*array of strings*): This REQUIRED property contains the list of X.509 certificate or certificate chain([RFC5280](https://datatracker.ietf.org/doc/html/rfc5280)) corresponding to the key used to digitally sign the JWS. The certificate containing the public key corresponding to the key used to digitally sign the JWS MUST be the first certificate.
+- **`timestamp`** (*string*): This OPTIONAL property is used to store time stamp token.
+  Only [RFC3161]([rfc3161](https://datatracker.ietf.org/doc/html/rfc3161#section-2.4.2)) compliant TimeStampToken are supported.
+- **`x5c`** (*array of strings*): This REQUIRED property contains the list of X.509 certificate or certificate chain([RFC5280](https://datatracker.ietf.org/doc/html/rfc5280)) corresponding to the key used to digitally sign the JWS.
+  The certificate containing the public key corresponding to the key used to digitally sign the JWS MUST be the first certificate.
 
-**Signature**: In JWS signature is calculated by combining JWSPayload and protected headers. The process is described below:
+- **`timestamp`** (*string*): This OPTIONAL property is used to store time stamp token.
+  Only [RFC3161]([rfc3161](https://datatracker.ietf.org/doc/html/rfc3161#section-2.4.2)) compliant TimeStampToken are supported.
+- **`x5c`** (*array of strings*): This REQUIRED property contains the list of X.509 certificate or certificate chain([RFC5280](https://datatracker.ietf.org/doc/html/rfc5280)) corresponding to the key used to digitally sign the JWS.
+  The certificate containing the public key corresponding to the key used to digitally sign the JWS MUST be the first certificate.
+
+**Signature**: In JWS signature is calculated by combining JWSPayload and protected headers.
+The process is described below:
 
 1. Compute the Base64Url value of ProtectedHeaders.
 1. Compute the Base64Url value of JWSPayload.
 1. Build message to be signed by concatenating the values generated in step 1 and step 2 using '.'
 `ASCII(BASE64URL(UTF8(ProtectedHeaders)) ‘.’ BASE64URL(JWSPayload))`
 1. Compute the signature on the message constructed in the previous step by using the signature algorithm defined in the corresponding header element: `alg`.
-1. Compute the Base64Url value of the signature produced in the previous step. This is the value of the signature property used in the signature envelope.
+1. Compute the Base64Url value of the signature produced in the previous step.
+   This is the value of the signature property used in the signature envelope.
 
 **Signature Envelope**: The final signature envelope comprises of Claims, ProtectedHeaders, UnprotectedHeaders, and signature.
 
@@ -207,7 +236,8 @@ Since Notary v2 restricts one signature per signature envelope, the compliant si
   | ECDSA on secp384r1 with SHA-384 | ES384             |
   | ECDSA on secp521r1 with SHA-512 | ES512             |
 1. Signing certificate MUST be a valid codesigning certificate.
-1. Only JWS JSON flattened format is supported. See 'Signature Envelope' section.
+1. Only JWS JSON flattened format is supported.
+   See 'Signature Envelope' section.
 
 ## Signature Algorithm Requirements
 
@@ -239,7 +269,8 @@ The signing certificate's public key algorithm and size MUST be used to determin
 
 The **signing certificate** MUST meet the following minimum requirements:
 
-- The keyUsage extension MUST be present and MUST be marked critical. The bit positions for digitalSignature MUST be set ([RFC-5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3)).
+- The keyUsage extension MUST be present and MUST be marked critical.
+  The bit positions for digitalSignature MUST be set ([RFC-5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3)).
 - The extKeyUsage extension MUST be present and its value MUST be id-kp-codeSigning ([RFC-5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12)).
 - If the basicConstraints extension is present, the cA field MUST be set false ([RFC-5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9)).
 - The certificate MUST abide by the following key length restrictions:
@@ -248,8 +279,10 @@ The **signing certificate** MUST meet the following minimum requirements:
 
 The **timestamping certificate** MUST meet the following minimum requirements:
 
-- The keyUsage extension MUST be present and MUST be marked critical. The bit positions for digitalSignature MUST be set ([RFC-5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3)).
-- The extKeyUsage extension MUST be present and MUST be marked critical. The value of extension MUST be id-kp-timeStamping ([RFC-5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12)).
+- The keyUsage extension MUST be present and MUST be marked critical.
+  The bit positions for digitalSignature MUST be set ([RFC-5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3)).
+- The extKeyUsage extension MUST be present and MUST be marked critical.
+  The value of extension MUST be id-kp-timeStamping ([RFC-5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12)).
 - If the basicConstraints extension is present, the cA field MUST be set false ([RFC-5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9)).
 - The certificate MUST abide by the following key length restrictions:
   - For RSA public key, the key length MUST be 2048 bits or higher.

--- a/signing-and-verification-workflow.md
+++ b/signing-and-verification-workflow.md
@@ -6,18 +6,19 @@ This document describes how Notary v2 signs and verifies OCI artifacts.
 
 The user wants to sign an OCI artifact and push the signature to a repository.
 
-### Prerequisite
+### Signing Prerequisites
 
 - User has access to the signing certificate and private key or a remote signing service through a notation plug-in.
 
-### Steps
+### Signing Steps
 
 1. **Generate signature:** Using notation CLI or any other compliant signing tool, sign the OCI artifact. The signing tool should follow the following guideline.
     1. Verify that the signing certificate is valid and satisfies [certificate requirements](./signature-specification.md#certificate-requirements).
     1. Verify that the signing algorithm satisfies [algorithm requirements](./signature-specification.md#signature-algorithm-requirements).
     1. Generate signature.
         1. Generate signature using signature formats specified in [supported signature envelopes](./signature-specification.md#supported-signature-envelopes).
-        1. If the user wants to timestamp the signature, obtain an [RFC-3161](https://datatracker.ietf.org/doc/html/rfc3161.html) compliant timestamp for the signature generated in the previous step. Otherwise, continue to the next step.
+        1. If the user wants to timestamp the signature, obtain an [RFC-3161](https://datatracker.ietf.org/doc/html/rfc3161.html) compliant timestamp for the signature generated in the previous step.
+           Otherwise, continue to the next step.
             1. Verify that the timestamp signing certificate satisfies [certificate requirements](./signature-specification.md#certificate-requirements).
             1. Verify that the timestamp signing algorithm satisfies [algorithm requirements](./signature-specification.md#signature-algorithm-requirements).
         1. Embed timestamp to the signature envelope.
@@ -25,36 +26,50 @@ The user wants to sign an OCI artifact and push the signature to a repository.
 1. **Generate signature artifact manifest:** As decribed in [signature specification](./signature-specification.md#storage) create the Notary v2 signature artifact manifest for the signature envelope generated in step 1.
 1. **Push signature artifact manifest:** Push Notary v2 signature artifact manifest to the repository.
 
-The user pushes the OCI artifact to the repository before the signature generation process as the signature reference must exist for the signature push to succeed. See: [ORAS Artifact Push Validation](https://github.com/oras-project/artifacts-spec/blob/main/artifact-manifest.md#push-validation) for more info.
+The user pushes the OCI artifact to the repository before the signature generation process as the signature reference must exist for the signature push to succeed.
+See: [ORAS Artifact Push Validation](https://github.com/oras-project/artifacts-spec/blob/main/artifact-manifest.md#push-validation) for more info.
 
 ## Verification workflow
 
 The user wants to pull an OCI artifact only if they are signed by a trusted publisher and the signature is valid.
 
-### Prerequisites
+### Verification Prerequisites
 
-- User has a fully qualified reference to an OCI artifact they want to pull. If the fully qualified artifact reference contains a tag then the user needs to resolve this tag to a digest.
-
-    E.g. If a fully qualified reference is `wabbit-networks.io/software:Latest` where `Latest` is a tag pointing to an artifact. The user must resolve the `Latest` tag to a digest and construct a new artifact reference using the resolved digest `wabbit-networks.io/software@sha256:${digest}`.
+- User has a fully qualified reference to an OCI artifact they want to pull.
+  If the fully qualified artifact reference contains a tag then the user needs to resolve this tag to a digest.
+  E.g. If a fully qualified reference is `wabbit-networks.io/software:latest` where `latest` is a tag pointing to an artifact.
+  The user must resolve the `latest` tag to a digest and construct a new artifact reference using the resolved digest `wabbit-networks.io/software@sha256:${digest}`.
 - User has configured [trust store and trust policy](./trust-store-trust-policy-specification.md) required for signature verification.
 
-### Steps
+### Verification Steps
 
-1. **Should Notary v2 verify the signature? :** Depending upon [trust-policy](./trust-store-trust-policy-specification.md#trust-policy) configuration, determine whether Notary v2 needs to verify the signature or not. If signature verification should be skipped for the given artifact, skip the below steps and directly jump to step 4.
-1. **Get signature artifact descriptors:** Using the ORAS [Manifest Referrers API](https://github.com/oras-project/artifacts-spec/blob/main/manifest-referrers-api.md) download the Notary v2 signature artifact descriptors. The  `artifactType` parameter is set to Notary v2 signature's artifact type `application/vnd.cncf.notary.v2.signature`. Note that all ORAS implementations may not support filtering using `artifactType`.
+1. **Should Notary v2 verify the signature? :** Depending upon [trust-policy](./trust-store-trust-policy-specification.md#trust-policy) configuration, determine whether Notary v2 needs to verify the signature or not.
+   If signature verification should be skipped for the given artifact, skip the below steps and directly jump to step 4.
+1. **Get signature artifact descriptors:** Using the ORAS [Manifest Referrers API](https://github.com/oras-project/artifacts-spec/blob/main/manifest-referrers-api.md) download the Notary v2 signature artifact descriptors.
+   The  `artifactType` parameter is set to Notary v2 signature's artifact type `application/vnd.cncf.notary.v2.signature`.
+   Note that all ORAS implementations may not support filtering using `artifactType`.
 1. For each signature artifact descriptor, perform the following steps:
     1. **Get signature artifact manifest:** Download the Notary v2 signature's artifact manifest for the given artifact descriptor.
     1. **Filter signature artifact manifest:**
         1. Filter out the unsupported signature formats by comparing the signature envelope format type (`[descriptors].descriptor.mediaType`) in the signature manifest, with the supported formats defined in [signature specification](./signature-specification.md#storage).
         1. Depending upon the trust-store and trust-policy configuration, further filter out signature manifests.
             1. Using the `scopes` configured in trust policies, get the applicable trust policy.
-            1. Get the list of trusted certificates from the trust stores specified in the applicable trust policy. If the trust policy contains multiple trust stores, create a list of trusted certificates by merging the trusted certificate list of each trust store.
+            1. Get the list of trusted certificates from the trust stores specified in the applicable trust policy.
+               If the trust policy contains multiple trust stores, create a list of trusted certificates by merging the trusted certificate list of each trust store.
                 1. Calculate the SHA-256 fingerprint of all the trusted certificates and compare them against the list of SHA-256 certificate fingerprints present in  `org.cncf.notary.x509certs.fingerprint.sha256` annotation of artifact manifest.
-                1. If there is at least one match, continue to the next step. Otherwise, move to the next signature artifact descriptor(step 3.1). If all signature artifact descriptors have already been processed, fail the signature verification and exit.
-        1. If the artifact manifest is filtered out, skip the below steps and move to the next signature artifact descriptor(step 3.1). If all signature artifact descriptors have already been processed, fail the signature verification and exit.
+                1. If there is at least one match, continue to the next step.
+                   Otherwise, move to the next signature artifact descriptor(step 3.1).
+                   If all signature artifact descriptors have already been processed, fail the signature verification and exit.
+        1. If the artifact manifest is filtered out, skip the below steps and move to the next signature artifact descriptor(step 3.1).
+           If all signature artifact descriptors have already been processed, fail the signature verification and exit.
     1. **Get and verify signatures:** On the filtered Notary v2 signature artifact manifest, perform the following steps:
         1. Download the signature envelope.
         1. Verify the signature envelope using trust-store and trust-policy as mentioned in [signature evaluation](./trust-store-trust-policy-specification.md#signature-evaluation) section.
-        1. If the signature verification fails, skip the below steps and move to the next signature artifact descriptor(step 3.1). If all signature artifact descriptors have already been processed, fail the signature verification and exit.
-        1. If signature verification succeeds, compare the digest derived from the given OCI artifact reference with the signed digest present in the signature envelope's payload. If digests are equal, signature verification is considered successful. Otherwise, move to the next signature artifact descriptor(step 3.1). If all signature artifact descriptors have already been processed, fail the signature verification and exit.
-1. **Get OCI artifact:** Using the verified digest, download the OCI artifact. This step is not in the purview of Notary v2.
+        1. If the signature verification fails, skip the below steps and move to the next signature artifact descriptor(step 3.1).
+           If all signature artifact descriptors have already been processed, fail the signature verification and exit.
+        1. If signature verification succeeds, compare the digest derived from the given OCI artifact reference with the signed digest present in the signature envelope's payload.
+           If digests are equal, signature verification is considered successful.
+           Otherwise, move to the next signature artifact descriptor(step 3.1).
+           If all signature artifact descriptors have already been processed, fail the signature verification and exit.
+1. **Get OCI artifact:** Using the verified digest, download the OCI artifact.
+   This step is not in the purview of Notary v2.

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -1,11 +1,13 @@
-## Threat model
+# Threat model
 
 It is assumed that an attacker may perform one or more the following actions:
 
-1. intercept and alter network traffic
-2. compromise some set of weak crypto algorithms which are supported in some legacy cases
-3. compromise a repository, including gaining access to use any keys stored on the repository
-4. compromise a signing key, for example due to malicious action or accidental disclosure by the key owner
-5. compromise a step in the software supply chain.  This can happen in many different ways, such as by gaining access to the server, compromising the software used in the step of the supply chain, passing different software to a subsequent step than what was intended, or causing an operator to make an error in a step.
+1. Intercept and alter network traffic.
+1. Compromise some set of weak crypto algorithms which are supported in some legacy cases.
+1. Compromise a repository, including gaining access to use any keys stored on the repository.
+1. Compromise a signing key, for example due to malicious action or accidental disclosure by the key owner.
+1. Compromise a step in the software supply chain.
+   This can happen in many different ways, such as by gaining access to the server, compromising the software used in the step of the supply chain, passing different software to a subsequent step than what was intended, or causing an operator to make an error in a step.
 
-While it is not always possible to protect against all scenarios, the system should to the extent possible mitigate and/or reduce the damage caused by a successful attack, detect the occurrence of an attack and notify appropriate parties, yet remain usable for parties operating the system.  Furthermore, the system should recover from successful attacks in a way that presents low operational overhead and risk to users.
+While it is not always possible to protect against all scenarios, the system should to the extent possible mitigate and/or reduce the damage caused by a successful attack, detect the occurrence of an attack and notify appropriate parties, yet remain usable for parties operating the system.
+Furthermore, the system should recover from successful attacks in a way that presents low operational overhead and risk to users.

--- a/trust-store-trust-policy-specification.md
+++ b/trust-store-trust-policy-specification.md
@@ -1,13 +1,15 @@
 # Trust Store and Trust Policy Specification
 
-This document describes how Notary v2 signatures are evaluated for trust. The document consists of the following sections:
+This document describes how Notary v2 signatures are evaluated for trust.
+The document consists of the following sections:
 
 - **[Trust Store](#trust-store)**: Defines set of signing identity that user trusts.
 - **[Trust Policy](#trust-policy)**: Defines how the artifact is evaluated for trust.
 
 ## Trust Store
 
-Users who consume and execute the signed artifact from a registry need a mechanism to specify the trusted producers. This is where Trust Store is used.
+Users who consume and execute the signed artifact from a registry need a mechanism to specify the trusted producers.
+This is where Trust Store is used.
 
 Trust store allows users to specify two kinds of identities:
 
@@ -50,11 +52,16 @@ The trust store is represented as JSON data structure as shown below:
 
 Property Description:
 
-- **`version`**(*string*): This REQUIRED property is the version of the trust store. The supported value is `1.0`
-- **`trustStores`**(*object*): This REQUIRED property represents the parent node containing multiple trust stores. Each trust store is identified by the key associated with it like 'trust-store-name-1', 'trust-store-name-2'.
-  - **`identities`**(*object*): This REQUIRED property represents the collection of different types of identities. There are two types of identifies that Notary v2 supports: x509 certificates and x509 timestamping certificates.
-    - **`x509Certs`**(*array of strings*): This REQUIRED property specifies a list of x509 certificates in PEM format. The collection MUST contain at least one certificate.
-    - **`tsaX509Certs`**(*array of strings*): This OPTIONAL property specifies a list of x509 timestamping certificates in PEM format. If the `tsaX509Certs` key is present then collection MUST contain at least one timestamping certificate.
+- **`version`**(*string*): This REQUIRED property is the version of the trust store.
+  The supported value is `1.0`
+- **`trustStores`**(*object*): This REQUIRED property represents the parent node containing multiple trust stores.
+  Each trust store is identified by the key associated with it like 'trust-store-name-1', 'trust-store-name-2'.
+  - **`identities`**(*object*): This REQUIRED property represents the collection of different types of identities.
+    There are two types of identifies that Notary v2 supports: x509 certificates and x509 timestamping certificates.
+    - **`x509Certs`**(*array of strings*): This REQUIRED property specifies a list of x509 certificates in PEM format.
+      The collection MUST contain at least one certificate.
+    - **`tsaX509Certs`**(*array of strings*): This OPTIONAL property specifies a list of x509 timestamping certificates in PEM format.
+      If the `tsaX509Certs` key is present then collection MUST contain at least one timestamping certificate.
 
 ## Trust Policy
 
@@ -73,8 +80,10 @@ If artifact expiry validations are enforced the implementation MUST perform the 
 
 1. If signature expiry is present then signature MUST NOT be expired.
 1. If signing identity is certificate and
-    1. the timestamp signature is not present then the signing certificate and the certificate chain MUST NOT be expired.
-    1. the timestamp signature is present then the timestamp signature MUST be valid. At the time of timestamping, signing certificate (including certificate chain) MUST NOT be expired. Also, the timestamping certificate and certificate chain MUST NOT be expired.
+    1. The timestamp signature is not present then the signing certificate and the certificate chain MUST NOT be expired.
+    1. The timestamp signature is present then the timestamp signature MUST be valid.
+       At the time of timestamping, signing certificate (including certificate chain) MUST NOT be expired.
+       Also, the timestamping certificate and certificate chain MUST NOT be expired.
 
 ### Artifact Revocation
 
@@ -85,7 +94,8 @@ If revocation validations are enforced implementation MUST perform the following
 1. If signing identity is a certificate then signing certificate and certificate chain MUST NOT be revoked.
 1. If the timestamp signature is present then the timestamping certificate and certificate chain MUST NOT be revoked.
 
-The implementation MUST support both [OCSP](https://datatracker.ietf.org/doc/html/rfc6960) and [CRL](https://datatracker.ietf.org/doc/html/rfc5280) based revocations. Since revocation check requires network call and network call can fail because of a variety of reasons such as revocation endpoint is unavailable, network connectivity issue, DDoS attack, etc the implementation MUST support both `fail-open` or `fail-close` use cases.
+The implementation MUST support both [OCSP](https://datatracker.ietf.org/doc/html/rfc6960) and [CRL](https://datatracker.ietf.org/doc/html/rfc5280) based revocations.
+Since revocation check requires network call and network call can fail because of a variety of reasons such as revocation endpoint is unavailable, network connectivity issue, DDoS attack, etc the implementation MUST support both `fail-open` or `fail-close` use cases.
 
 - `fail-open`: If revocation endpoint is not reachable, consider artifact as not revoked.
 - `fail-close`: If revocation endpoint is not reachable, consider artifact as revoked.
@@ -141,20 +151,34 @@ The trust policy is represented as JSON data structure as shown below:
 
 Property descriptions
 
-- **`version`**(*string*): This REQUIRED property is the version of the trust policy. The supported value is `1.0`.
+- **`version`**(*string*): This REQUIRED property is the version of the trust policy.
+  The supported value is `1.0`.
 - **`trustPolicies`**(*string-array of objects map*): This REQUIRED property represents a collection of trust policies.
   - **`name`**(*string*): This REQUIRED propert represents the name of the trust policy.
-  - **`scopes`**(*array of strings*): This REQUIRED property determines which trust policy is applicable for the given artifact. The scope field supports filtering based on fully qualified repository URI `${registry-name}/${namespace}/${repository-name}`. For more information, see [scopes constraints](#scope-constraints) section.
-  - **`skipSignatureVerification`**(*boolean*): This OPTIONAL property dictates whether Notary v2 should skip signature verification or not. If set to `true` Notary v2 MUST NOT perform any signature validations including the custom validations performed using plugins. This is required to support the gradual rollout of signature validation i.e the case when the user application has a mix of signed and unsigned artifacts. When set to `false`, the following properties  MUST be present `trustStores`, `expiryValidations`, `revocationValidations`. The default value is `false`.
+  - **`scopes`**(*array of strings*): This REQUIRED property determines which trust policy is applicable for the given artifact.
+    The scope field supports filtering based on fully qualified repository URI `${registry-name}/${namespace}/${repository-name}`.
+    For more information, see [scopes constraints](#scope-constraints) section.
+  - **`skipSignatureVerification`**(*boolean*): This OPTIONAL property dictates whether Notary v2 should skip signature verification or not.
+    If set to `true` Notary v2 MUST NOT perform any signature validations including the custom validations performed using plugins.
+    This is required to support the gradual rollout of signature validation i.e the case when the user application has a mix of signed and unsigned artifacts.
+    When set to `false`, the following properties  MUST be present `trustStores`, `expiryValidations`, `revocationValidations`.
+    The default value is `false`.
   - **`trustStores`**(*array of strings*): This OPTIONAL property specifies a list of names of trust stores that the user trusts.
-  - **`trustAnchors`**(*array of strings*): This OPTIONAL property specifies a list of elements/attributes of the signing certificate's subject. If present, the collection MUST contain at least one value. For more information, see [trust anchors constraints](#trust-anchors-constraints) section.
+  - **`trustAnchors`**(*array of strings*): This OPTIONAL property specifies a list of elements/attributes of the signing certificate's subject.
+    If present, the collection MUST contain at least one value.
+    For more information, see [trust anchors constraints](#trust-anchors-constraints) section.
   - **`expiryValidations`**(*object*): This OPTIONAL property represents a collection of artifact expiry-related validations.
-    - **`signatureExpiry`**(*string*): This REQUIRED property specifies what implementation must do if the signature is expired.  Supported values are `enforce` and `warn`.
-    - **`signingIdentityExpiry`**(*string*): This REQUIRED property specifies what implementation must do if signing identity(certificate and certificate-chain) is expired. Supported values are `enforce` and `warn`.
-    - **`timestampExpiry`**(*string*): This REQUIRED property specifies what implementation must do if timestamping certificate and certificate-chain are expired. Supported values are `enforce` and `warn`.
+    - **`signatureExpiry`**(*string*): This REQUIRED property specifies what implementation must do if the signature is expired.
+      Supported values are `enforce` and `warn`.
+    - **`signingIdentityExpiry`**(*string*): This REQUIRED property specifies what implementation must do if signing identity(certificate and certificate-chain) is expired.
+      Supported values are `enforce` and `warn`.
+    - **`timestampExpiry`**(*string*): This REQUIRED property specifies what implementation must do if timestamping certificate and certificate-chain are expired.
+      Supported values are `enforce` and `warn`.
   - **`revocationValidations`**(*object*): This OPTIONAL property represents collection of artifact revocation related validations.
-    - **`signingIdentityRevocation`**(*string*): This REQUIRED property specifies whether implementation should check for signing identity(certificate and certificate-chain) revocation status or not and what implementation must do if this revocation check fails. Supported values are `enforceWithFailOpen`, `enforceWithFailClose`, `warn` and `skip`.
-    - **`timestampRevocation`**(*string*): This REQUIRED property specifies whether implementation should check for timestamping certificate and certificate-chain revocation status or not and what implementation must do if this revocation check fails. Supported values are `enforceWithFailOpen`, `enforceWithFailClose`, `warn` and `skip`.
+    - **`signingIdentityRevocation`**(*string*): This REQUIRED property specifies whether implementation should check for signing identity(certificate and certificate-chain) revocation status or not and what implementation must do if this revocation check fails.
+      Supported values are `enforceWithFailOpen`, `enforceWithFailClose`, `warn` and `skip`.
+    - **`timestampRevocation`**(*string*): This REQUIRED property specifies whether implementation should check for timestamping certificate and certificate-chain revocation status or not and what implementation must do if this revocation check fails.
+      Supported values are `enforceWithFailOpen`, `enforceWithFailClose`, `warn` and `skip`.
 
 Value descriptions
 
@@ -168,27 +192,43 @@ Value descriptions
 
 - Each trust policy MUST contain scope property and the scope collection MUST contain at least one value.
 - The scope MUST contain one of the following:
-  - List of one or more fully qualified repository URIs. The repository URI MUST NOT contain the asterisk character `*`.
-  - A single value with one asterisk character `*`. The scope with `*` value is called global scope. The trust policy with global scope applies to all the artifacts. There can only be one trust policy that uses a global scope.
+  - List of one or more fully qualified repository URIs.
+    The repository URI MUST NOT contain the asterisk character `*`.
+  - A single value with one asterisk character `*`.
+    The scope with `*` value is called global scope.
+    The trust policy with global scope applies to all the artifacts.
+    There can only be one trust policy that uses a global scope.
 - For a given artifact there MUST be only one applicable trust policy, except for trust policy with global scope.
 - For a given artifact, if there is no applicable trust policy then Notary v2 MUST consider the artifact as untrusted and fail signature verification.
-- The scope MUST NOT support reference expansion i.e. URIs must be fully qualified. E.g. the scope should be `docker.io/library/registry` rather than `registry`.
+- The scope MUST NOT support reference expansion i.e. URIs must be fully qualified.
+  E.g. the scope should be `docker.io/library/registry` rather than `registry`.
 - Evaluation order of trust policies:
-  1. *Exact match*: If there exists a trust policy whose scope contains the artifact's repository URI then the aforementioned policy MUST be used for signature evaluation. Otherwise, continue to the next step.
-  1. *Global*: If there exists a trust policy with global scope then use that policy for signature evaluation. Otherwise, fail the signature verification.
+  1. *Exact match*: If there exists a trust policy whose scope contains the artifact's repository URI then the aforementioned policy MUST be used for signature evaluation.
+     Otherwise, continue to the next step.
+  1. *Global*: If there exists a trust policy with global scope then use that policy for signature evaluation.
+     Otherwise, fail the signature verification.
 
 ### Trust Anchors Constraints
 
-A distinguished name (usually just shortened to "DN") uniquely identifies an entry and in the case of the certificate's subject, DN uniquely identifies the requestor/holder of the certificate. The DN is comprised of zero or more comma-separated components called relative distinguished names, or RDNs. For example, the DN `C=US, ST=WA, O=wabbit-network.io, OU=org1`"` has four RDNs. The RDN consists of an attribute type name followed by an equal sign and the string representation of the corresponding attribute value.
+A distinguished name (usually just shortened to "DN") uniquely identifies an entry and in the case of the certificate's subject, DN uniquely identifies the requestor/holder of the certificate.
+The DN is comprised of zero or more comma-separated components called relative distinguished names, or RDNs.
+For example, the DN `C=US, ST=WA, O=wabbit-network.io, OU=org1`"` has four RDNs.
+The RDN consists of an attribute type name followed by an equal sign and the string representation of the corresponding attribute value.
 
 - Trust anchor MUST support a full and partial list of all the attribute types present in [subject DN](https://www.rfc-editor.org/rfc/rfc5280.html#section-4.1.2.6) of x509 certificate.
 - If the subject DN of the signing certificate is used in the trust anchor, then it MUST meet the following requirements:
-  - The value of `trustAnchors` MUST begin with `subject:` followed by comma-separated one or more RDNs. For example, `subject: C=${country}, ST=${state}, L=${locallity}, O={organization}, OU=${organization-unit}, CN=${common-name}`.
-  - Trust anchor MUST contain country (CN), state Or province (ST), and organization (O) RDNs. All other RDNs are optional. The minimal possible trust anchor is `subject: C=${country}, ST=${state}, O={organization}`,
-  - Trust anchor MUST NOT have overlapping values. Trust anchors are considered overlapping if there exists a certificate for which multiple trust anchors evaluate true. For example, the following two trust anchors are overlapping:
+  - The value of `trustAnchors` MUST begin with `subject:` followed by comma-separated one or more RDNs.
+    For example, `subject: C=${country}, ST=${state}, L=${locallity}, O={organization}, OU=${organization-unit}, CN=${common-name}`.
+  - Trust anchor MUST contain country (CN), state Or province (ST), and organization (O) RDNs.
+    All other RDNs are optional.
+    The minimal possible trust anchor is `subject: C=${country}, ST=${state}, O={organization}`,
+  - Trust anchor MUST NOT have overlapping values.
+    Trust anchors are considered overlapping if there exists a certificate for which multiple trust anchors evaluate true.
+    For example, the following two trust anchors are overlapping:
     - `subject: C=US, ST=WA, O=wabbit-network.io, OU=org1`
     - `subject:  C=US, ST=WA, O=wabbit-network.io`
-  - In some special cases trust anchor MUST escape one or more characters in an RDN. Those cases are:
+  - In some special cases trust anchor MUST escape one or more characters in an RDN.
+    Those cases are:
     - If a value starts or ends with a space, then that space character MUST be escaped as `\`.
     - All occurrences of the comma character (`,`) MUST be escaped as `\,`.
     - All occurrences of the semicolon character (`;`) MUST be escaped as `\;`.
@@ -196,7 +236,8 @@ A distinguished name (usually just shortened to "DN") uniquely identifies an ent
 
 ### Extended Validation
 
-The implementation must allow the user to execute custom validations. These custom validation MUST have access to all the information available in the signature envelope like payload, signed attributes, unsigned attributes, and signature.
+The implementation must allow the user to execute custom validations.
+These custom validation MUST have access to all the information available in the signature envelope like payload, signed attributes, unsigned attributes, and signature.
 
 ## Signature Evaluation
 
@@ -214,77 +255,110 @@ The implementation must allow the user to execute custom validations. These cust
     1. Get the signing algorithm(hash+encryption) from the signing certificate and validate that the signing algorithm satisfies [algorithm requirements](./signature-specification.md#signature-algorithm-requirements)
     1. Using the public key of the signing certificate and signing algorithm identified in the previous step, validate the integrity of the signature envelope.
 1. **Validate the signature against trust policy and trust store.**
-    1. Using the `scope` configured in trust policies, get the applicable trust policy. (Implementations might have this value precomputed, added it for completeness)
+    1. Using the `scope` configured in trust policies, get the applicable trust policy.
+       (Implementations might have this value precomputed, added it for completeness)
     1. For the applicable trust policy, **validate trust-store:**
-        1. Validate that the signature envelope contains a complete certificate chain that starts from a code signing certificate and terminates with the root certificate. Also, validate that code signing certificate satisfies [certificate requirements](./signature-specification.md#certificate-requirements).
+        1. Validate that the signature envelope contains a complete certificate chain that starts from a code signing certificate and terminates with the root certificate.
+           Also, validate that code signing certificate satisfies [certificate requirements](./signature-specification.md#certificate-requirements).
         1. For each of the trust-stores configured in applicable trust-policy perform the following steps.
             1. Validate that certificate and certificate-chain lead to a trusted certificate configured in the `x509Certs` field of trust-store.
-            1. If the above verification succeeds then continue to the next step else iterate over the next trust store. If all of the trust stores have been evaluated then fail the signature validation and exit.
+            1. If the above verification succeeds then continue to the next step else iterate over the next trust store.
+               If all of the trust stores have been evaluated then fail the signature validation and exit.
     1. For the applicable trust policy, **validate trust anchors** (if present):
-        1. If trust anchors are present, validate that the value of subject attributes configured in `trustAnchors` matches with the value of corresponding attributes in the signing certificate’s subject. If trust anchors are not present continue to step 4.
-        1. If the above verification succeeds then continue to the next step. Otherwise, fail the signature validation and exit.
+        1. If trust anchors are present, validate that the value of subject attributes configured in `trustAnchors` matches with the value of corresponding attributes in the signing certificate’s subject.
+           If trust anchors are not present continue to step 4.
+        1. If the above verification succeeds then continue to the next step.
+           Otherwise, fail the signature validation and exit.
     1. **Validate trust policy:**
-        1. If signature expiry is present in the signature envelope, using the local machine’s current time(in UTC) check whether the signature is expired or not. If the signature is not expired, continue to the next step. Otherwise, if `signatureExpiry` is set to `Enforce` then fail the signature validation and exit else log a warning and continue to the next step.
+        1. If signature expiry is present in the signature envelope, using the local machine’s current time(in UTC) check whether the signature is expired or not.
+           If the signature is not expired, continue to the next step.
+           Otherwise, if `signatureExpiry` is set to `Enforce` then fail the signature validation and exit else log a warning and continue to the next step.
         1. Check for the timestamp signature in the signature envelope.
-            1. If the timestamp exists, continue with the next step. Otherwise, store the local machine's current time(in  UTC) in variables `timeStampLowerLimit` and `timeStampUpperLimit` and continue with step 3.3.c.
+            1. If the timestamp exists, continue with the next step.
+               Otherwise, store the local machine's current time(in  UTC) in variables `timeStampLowerLimit` and `timeStampUpperLimit` and continue with step 3.3.c.
             1. Validate that the timestamp hash in `TSTInfo.messageImprint` matches the hash of the signature to which the timestamp was applied.
             1. Validate that the timestamp signing certificate satisfies [certificate requirements](./signature-specification.md#certificate-requirements).
             1. Validate that the timestamp signing algorithm satisfies [algorithm requirements](./signature-specification.md#signature-algorithm-requirements).
             1. Validate the `signing-certificate`([RFC-2634](https://tools.ietf.org/html/rfc2634)) or `signing-certificate-v2`([RFC-5126](https://tools.ietf.org/html/rfc5126#section-5.7.3.2)) attribute of timestamp CMS.
-            1. Check whether timestamping certificate and certificate chain are valid (not expired) or not. If timestamping certificate and certificate-chain are not expired, continue to the next step. Otherwise, if `timestampExpiry` in trust-policy is configured to `Enforce` then fail the signature validation and exit, else log a warning and continue to the next step.
+            1. Check whether timestamping certificate and certificate chain are valid (not expired) or not.
+               If timestamping certificate and certificate-chain are not expired, continue to the next step.
+               Otherwise, if `timestampExpiry` in trust-policy is configured to `Enforce` then fail the signature validation and exit, else log a warning and continue to the next step.
             1. Validate that timestamp certificate and certificate chain leads to a trusted TSA certificate configured in trust policy.
             1. Validate timestamp certificate and certificate chain revocation status  using [certificate revocation evaluation](#certificate-revocation-evaluation) section as per `timestampRevocation` setting in trust-policy
             1. Retrieve the timestamp's time from `TSTInfo.genTime`.
-            1. Retrieve the timestamp's accuracy.  If the accuracy is explicitly specified in `TSTInfo.accuracy`, use that value.  If the accuracy is not explicitly specified and `TSTInfo.policy` is the baseline time-stamp policy([RFC-3628](https://tools.ietf.org/html/rfc3628#section-5.2)), use accuracy of 1 second.  Otherwise, use an accuracy of 0.
+            1. Retrieve the timestamp's accuracy.
+               If the accuracy is explicitly specified in `TSTInfo.accuracy`, use that value.
+               If the accuracy is not explicitly specified and `TSTInfo.policy` is the baseline time-stamp policy([RFC-3628](https://tools.ietf.org/html/rfc3628#section-5.2)), use accuracy of 1 second.
+               Otherwise, use an accuracy of 0.
             1. Calculate the timestamp range using the lower and upper limits per [RFC-3161 section 2.4.2](https://tools.ietf.org/html/rfc3161#section-2.4.2) and store the limits as `timeStampLowerLimit` and `timeStampUpperLimit` variables respectively.
-        1. Check that the time range from `timeStampLowerLimit` to `timeStampUpperLimit` timestamp is entirely within the certificate's validity period.  If the time range is entirely within the signing certificate and certificate chain's validity period, continue to the next step.  Otherwise, If `signingIdentityExpiry` in trust-policy is configured to `Enforce` then fail the signature validation and exit else log a warning and continue to the next step.
+        1. Check that the time range from `timeStampLowerLimit` to `timeStampUpperLimit` timestamp is entirely within the certificate's validity period.
+           If the time range is entirely within the signing certificate and certificate chain's validity period, continue to the next step.
+           Otherwise, If `signingIdentityExpiry` in trust-policy is configured to `Enforce` then fail the signature validation and exit else log a warning and continue to the next step.
         1. Validate signing identity(certificate and certificate chain) revocation status using [certificate revocation evaluation](#certificate-revocation-evaluation) section as per `signingIdentityRevocation` setting in trust-policy.
         1. Perform extended validation using the applicable(if any) plugin.
         1. If you have reached this step then treat the OCI artifact signature as a valid signature.
 
 ### Certificate Revocation Evaluation
 
-If the certificate revocation trust-store setting is set to `skip`, skip the below steps. Otherwise, check for revocation status for certificate and certificate chain.
+If the certificate revocation trust-store setting is set to `skip`, skip the below steps.
+therwise, check for revocation status for certificate and certificate chain.
 
-1. If the revocation status of any of the certificates cannot be determined (revocation unavailable) and `signingIdentityRevocation` is set to either `enforceWithFailOpen` or `warn` then log a warning and skip the below steps. Otherwise, fail the signature validation and exit.
+1. If the revocation status of any of the certificates cannot be determined (revocation unavailable) and `signingIdentityRevocation` is set to either `enforceWithFailOpen` or `warn` then log a warning and skip the below steps.
+   Otherwise, fail the signature validation and exit.
 1. If any of the certificates are revoked and `signingIdentityRevocation` is set to either `enforceWithFailOpen` or `enforceWithFailClose` then fail signature validation and exit else log a warning.
 
 Starting from Root to leaf certificate, for each certificate in the certificate chain, perform the following steps to check its revocation status:
 
 - If the certificate being validated doesn't include information OCSP or CRLs then no revocation check is performed and the certificate is considered valid(not revoked).
 - If the certificate being validated includes either OCSP or CRL information, then the one which is present is used for revocation check.
-- If both OCSP URLs and CDP URLs are present, then OCSP is preferred over CRLs. If revocation status cannot be determined using OCSP because of any reason such as unavailability then fallback to using CRLs for revocation check.
+- If both OCSP URLs and CDP URLs are present, then OCSP is preferred over CRLs.
+  If revocation status cannot be determined using OCSP because of any reason such as unavailability then fallback to using CRLs for revocation check.
 
 #### CRLs
 
 There are two types of CRLs (per RFC 3280), Base CRLs and Delta CRls.
 
-- **Base CRLs:** Contains the revocation status of all certificates that have been issued by a given CA. BaseCRLs are signed by the certificate issuing CAs.
-- **Delta CRLs:** Contains only certificates that have changed status since the last base CRL was published. Delta CRLs are signed by the certificate issuing CAs.
+- **Base CRLs:** Contains the revocation status of all certificates that have been issued by a given CA.
+  BaseCRLs are signed by the certificate issuing CAs.
+- **Delta CRLs:** Contains only certificates that have changed status since the last base CRL was published.
+  Delta CRLs are signed by the certificate issuing CAs.
 - **Indirect CRLs:** Special Case in which BaseCRLs and Delta CRLs are not signed by the certificate issuing CAs, instead they are signed with a completely different certificate.
 
-Notary v2 MUST support BaseCRLs and Delta CRLs. Notary v2 MAY support Indirect CRLs. Notary v2 supports only HTTP CRL URLs.
+Notary v2 MUST support BaseCRLs and Delta CRLs.
+Notary v2 MAY support Indirect CRLs.
+Notary v2 supports only HTTP CRL URLs.
 
 Implementations MAY add support for caching CRLs and OCSP response to improve availability, latency and avoid network overhead.
 
 ##### CRL Download
 
-CRL download location (URL) can be obtained from the certificate's CRL Distribution Point (CDP) extension. If the certificate contains multiple CDP locations then each location download is attempted in sequential order. For each CDP location, Notary V2 will try to download the CRL for the default threshold of 10 seconds. If the CRL cannot be downloaded within the timeout threshold the revocation result will be "revocation unavailable". The user may be able to configure this threshold.
+CRL download location (URL) can be obtained from the certificate's CRL Distribution Point (CDP) extension.
+If the certificate contains multiple CDP locations then each location download is attempted in sequential order.
+For each CDP location, Notary V2 will try to download the CRL for the default threshold of 10 seconds.
+If the CRL cannot be downloaded within the timeout threshold the revocation result will be "revocation unavailable".
+The user may be able to configure this threshold.
 
 ##### Revocation Checking with CRL
 
 To check the revocation status of a certificate against CRL, the following steps must be performed:
 
 1. Verify the CRL signature.
-1. Verify that the CRL is valid (not expired). A CRL is considered expired if the current date is after the `NextUpdate` field in the CRL.
+1. Verify that the CRL is valid (not expired).
+   A CRL is considered expired if the current date is after the `NextUpdate` field in the CRL.
 1. Look up the certificate’s serial number in the CRL.
-    1. If the certificate’s serial number is listed in the CRL, look for `InvalidityDate`. If CRL has an invalidity date and artifact signature is timestamped then compare the invalidity date with the timestamping date. If the invalidity date is before the timestamping date, the certificate is considered revoked. If the invalidity date is not present in CRL, the certificate is considered revoked.
+    1. If the certificate’s serial number is listed in the CRL, look for `InvalidityDate`.
+       If CRL has an invalidity date and artifact signature is timestamped then compare the invalidity date with the timestamping date.
+       If the invalidity date is before the timestamping date, the certificate is considered revoked.
+       If the invalidity date is not present in CRL, the certificate is considered revoked.
     1. If the CRL is expired and the certificate is listed in the CRL for any reason other than `certificate hold`, the certificate is considered revoked.
-    1. If the certificate is not listed in the CRL or the revocation reason is `certificate hold`, a new CRL is retrieved if the current time is past the time in the `NextUpdate` field in the current CRL. The new CRL is then checked to determine if the certificate is revoked. If the original reason was `certificate hold`, the CRL is checked to determine if the certificate is unrevoked by looking for the `RemoveFromCRL` revocation code.
+    1. If the certificate is not listed in the CRL or the revocation reason is `certificate hold`, a new CRL is retrieved if the current time is past the time in the `NextUpdate` field in the current CRL.
+       The new CRL is then checked to determine if the certificate is revoked.
+       If the original reason was `certificate hold`, the CRL is checked to determine if the certificate is unrevoked by looking for the `RemoveFromCRL` revocation code.
 
 ##### Revocation Checking with Delta CRLs
 
-If a delta CRL exists for a base CRL, the `Freshest CRL` extension in the base CRL provides the URL from where the delta CRL can be downloaded. The delta CRLs have their identifying number, plus the "Delta CRL Indicator" extension indicating the version number of the base CRL that must be used with the delta CRL.
+If a delta CRL exists for a base CRL, the `Freshest CRL` extension in the base CRL provides the URL from where the delta CRL can be downloaded.
+The delta CRLs have their identifying number, plus the "Delta CRL Indicator" extension indicating the version number of the base CRL that must be used with the delta CRL.
 
 When delta CRLs are implemented, the following results can occur during revocation checking.
 
@@ -296,23 +370,32 @@ When delta CRLs are implemented, the following results can occur during revocati
 
 ##### OCSP Download
 
-OCSP URLs can be obtained from the certificate's authority information access (AIA) extension as defined in [RFC-2560](https://datatracker.ietf.org/doc/html/rfc2560). Notary V2 will wait for a default threshold of 5 seconds to receive an OCSP response. If OCSP response is not available within the timeout threshold the revocation result will be "revocation unavailable". The user may be able to configure this threshold.
+OCSP URLs can be obtained from the certificate's authority information access (AIA) extension as defined in [RFC-2560](https://datatracker.ietf.org/doc/html/rfc2560).
+Notary V2 will wait for a default threshold of 5 seconds to receive an OCSP response.
+If OCSP response is not available within the timeout threshold the revocation result will be "revocation unavailable".
+The user may be able to configure this threshold.
 
 ##### Revocation Checking with OCSP
 
 To check the revocation status of a certificate using OCSP, the following steps must be performed.
 
-1. Verify the signature of the OCSP response. This step also includes verifying the OSCP response signing certificate is valid and trusted. The OCSP signing certificate must be issued by the same CA as the certificate being verified or the OCSP response must be signed by the issuing CA.
-1. Verify that the OCSP response is valid (not expired). A CRL is considered expired if the current date is after the `NextUpdate` field in the CRL.
+1. Verify the signature of the OCSP response.
+   This step also includes verifying the OSCP response signing certificate is valid and trusted.
+   The OCSP signing certificate must be issued by the same CA as the certificate being verified or the OCSP response must be signed by the issuing CA.
+1. Verify that the OCSP response is valid (not expired).
+   A CRL is considered expired if the current date is after the `NextUpdate` field in the CRL.
 1. Verify that the OCSP response indicates that the certificate is not revoked i.e `CertStatus` is `good`.
-    1. If the certificate is revoked i.e `CertStatus` is `revoked`, look for `InvalidityDate`. If the invalidity date is present and timestamp signature is also present then if the invalidity date is before the timestamping date, the certificate is considered revoked. If the invalidity date is not present in OCSP response, the certificate is considered revoked.
+    1. If the certificate is revoked i.e `CertStatus` is `revoked`, look for `InvalidityDate`.
+       If the invalidity date is present and timestamp signature is also present then if the invalidity date is before the timestamping date, the certificate is considered revoked.
+       If the invalidity date is not present in OCSP response, the certificate is considered revoked.
 1. If `id-pkix-ocsp-nocheck`(1.3.6.1.5.5.7.48.1.5) extension is not present on the OCSP signing certificate then revocation checking must be performed using CRLs for the OCSP signing certificate.
 
 ## FAQ
 
 **Q: Does Notary v2 supports `n` out of `m` signatures verification requirement?**
 
-**A:** Notary v2 doesn't support n out m signature requirement verification scheme. Signature verification workflow succeeds if verification succeeds for at least one signature.
+**A:** Notary v2 doesn't support n out m signature requirement verification scheme.
+Signature verification workflow succeeds if verification succeeds for at least one signature.
 
 **Q: Does Notary v2 support overriding of revocation endpoints to support signature verification in disconnected environments?**
 
@@ -324,5 +407,6 @@ To check the revocation status of a certificate using OCSP, the following steps 
 
 **Q: Why are we validating artifact signature first instead of signing identity?**
 
-**A:** Ideally, we should validate the signing identity first and then use the public key in the signing identity to validate the artifact signature. However, this will lead to poor performance in the case where the signature is not valid as there are lots of validations against the signing identity including network calls for revocations, and possibly we won't even need to read the trust store/trust policy if the signature validation fails.
+**A:** Ideally, we should validate the signing identity first and then use the public key in the signing identity to validate the artifact signature.
+However, this will lead to poor performance in the case where the signature is not valid as there are lots of validations against the signing identity including network calls for revocations, and possibly we won't even need to read the trust store/trust policy if the signature validation fails.
 Also, by validating artifact signature first we will still fail the validation if the signing identity is not trusted.

--- a/verification-by-reference.md
+++ b/verification-by-reference.md
@@ -5,42 +5,63 @@
 
 ## Overview
 
-One of the many questions of Notary v2 is how will verification (signatures) be persisted within a registry. This paper outlines an option for persisting verification content as additional artifacts in the registry, with a reverse lookup. This would enable multiple verifications to exist without changing the original artifact, or the digest of the original content.
+One of the many questions of Notary v2 is how will verification (signatures) be persisted within a registry.
+This paper outlines an option for persisting verification content as additional artifacts in the registry, with a reverse lookup.
+This would enable multiple verifications to exist without changing the original artifact, or the digest of the original content.
 
 ## Terms & references
 
-For the purposes of this document, we defer what a verification means. A verification may be a signature, where an org, company or entity states it attests to the current state of an artifact. Or a larger verification document that has additional content to prove verification of an artifact. This doc experiments with the avoidance of signatures as the reference.
+For the purposes of this document, we defer what a verification means.
+A verification may be a signature, where an org, company or entity states it attests to the current state of an artifact.
+Or a larger verification document that has additional content to prove verification of an artifact.
+This doc experiments with the avoidance of signatures as the reference.
 
 ## Goals
 
 1. An artifact and it’s digest shall not change as the result of a verification object being added.
-1. Verification steps along a workflow must not be required to change how they reference the target artifact. A kube deployment yaml, helm chart, or docker compose file must not be required to change their tag reference of ubuntu:1404 or ubuntu@sha256:2468 digest reference.
+1. Verification steps along a workflow must not be required to change how they reference the target artifact.
+   A kube deployment yaml, helm chart, or docker compose file must not be required to change their tag reference of ubuntu:1404 or ubuntu@sha256:2468 digest reference.
 1. A collection of verification objects may be associated with an artifact.
-1. Leverage the garbage collection infrastructure registry operators have implemented. 
-Garbage collection represents significant investments for registry services which are based on OCI Manifest and OCI Index. We should aim to utilize these existing schemas, or only slight verifications from them to maximize the opportunity for registry implementations to adopt Notary v2.
-1. Minimize requirements to change persistence and object stores used by registry operators. Similar to garbage collection, we should work within the constraints of manifest, index and layers to represent verification objects.
+1. Leverage the garbage collection infrastructure registry operators have implemented.
+   Garbage collection represents significant investments for registry services which are based on OCI Manifest and OCI Index.
+   We should aim to utilize these existing schemas, or only slight verifications from them to maximize the opportunity for registry implementations to adopt Notary v2.
+1. Minimize requirements to change persistence and object stores used by registry operators.
+   Similar to garbage collection, we should work within the constraints of manifest, index and layers to represent verification objects.
 
 ## Non-goals
 
-1. Work within the constraints of the existing OCI-distribution spec api set. 
-Supporting Notary v1, or Docker Content Trust, requires new APIs. APIs are comparatively cheap to implement atop the persistence stores of registries. 
-New APIs should be part of the Notary v2 spec, which may represent changes to the OCI-distribution spec or implementations of a new extension model over the Distribution spec.
-1. Compatibility with Notary v1. Registries that have implemented Notary v1 are looking for a better solution. We cumulatively have little existing usage, and if successful, we expect all customers would rapidly move to Notary v2 eliminating the need to maintain two sets of APIs for an extended period of time.
+1. Work within the constraints of the existing OCI-distribution spec api set.
+   Supporting Notary v1, or Docker Content Trust, requires new APIs.
+   APIs are comparatively cheap to implement atop the persistence stores of registries.
+   New APIs should be part of the Notary v2 spec, which may represent changes to the OCI-distribution spec or implementations of a new extension model over the Distribution spec.
+1. Compatibility with Notary v1.
+   Registries that have implemented Notary v1 are looking for a better solution.
+   We cumulatively have little existing usage, and if successful, we expect all customers would rapidly move to Notary v2 eliminating the need to maintain two sets of APIs for an extended period of time.
 
 ## Adding verifications along a workflow
 
-To address [Notary v2 Scenario #6: Multiple Signatures](https://github.com/notaryproject/requirements/blob/master/scenarios.md#scenario-6-multiple-signatures), an artifact must be capable of having additional signatures (verifications) be added. However, a deployment document (Helm chart, Kube deploy yaml) must not be required to change. 
+To address [Notary v2 Scenario #6: Multiple Signatures](https://github.com/notaryproject/requirements/blob/master/scenarios.md#scenario-6-multiple-signatures), an artifact must be capable of having additional signatures (verifications) be added.
+However, a deployment document (Helm chart, Kube deploy yaml) must not be required to change.
 
-1. A dev team builds a container image. `(web:a2b2)` They sign the image (provide verification).
-1. An artifact scanning solution validates the image, storing an assessment of the current state of known vulnerabilities. It pushes a verification object for `web:a2b2`, stating on May 1, 2020, it was verified.
-1. A test environment validates the image, it passes a set of tests and the image is promoted to staging. The image has a test verification added to the image. However, the deployment document doesn’t change the reference. It’s still referenced as `web:a2b2`. The additional verification document is associated with the image.
-1. A staging environment is requested to run the `web:a2b2` image, but requires scanning verification and test verification before the image can be run. 
-As the artifacts are approved in staging, another verification object is pushed to the registry, attesting to the images and the deployment documents have passed all tests, as of a given date.
-1. As the collection of artifacts are moved to production, a deployment policy verifies each artifact being requested for deployment has Staging, Test and Scanning verifications. The scanning verification must be within a given date range. Each verification must come from entities the production system trusts. 
+1. A dev team builds a container image, `(web:a2b2)`.
+   They sign the image (provide verification).
+1. An artifact scanning solution validates the image, storing an assessment of the current state of known vulnerabilities.
+   It pushes a verification object for `web:a2b2`, stating on May 1, 2020, it was verified.
+1. A test environment validates the image, it passes a set of tests and the image is promoted to staging.
+   The image has a test verification added to the image.
+   However, the deployment document doesn’t change the reference.
+   It’s still referenced as `web:a2b2`.
+   The additional verification document is associated with the image.
+1. A staging environment is requested to run the `web:a2b2` image, but requires scanning verification and test verification before the image can be run.
+   As the artifacts are approved in staging, another verification object is pushed to the registry, attesting to the images and the deployment documents have passed all tests, as of a given date.
+1. As the collection of artifacts are moved to production, a deployment policy verifies each artifact being requested for deployment has Staging, Test and Scanning verifications.
+   The scanning verification must be within a given date range.
+   Each verification must come from entities the production system trusts.
 
 ## Verification by downward reference
 
-The OCI distribution and image specs utilize OCI manifest and OCI index. These are json documents that provide downward references. 
+The OCI distribution and image specs utilize OCI manifest and OCI index.
+These are json documents that provide downward references.
 
 1. An OCI index references a collection of other OCI indexes and/or OCI manifests by their digest.
 
@@ -95,7 +116,9 @@ The OCI distribution and image specs utilize OCI manifest and OCI index. These a
     }
     ```
 
-We have been largely focusing on the need to support this downward reference model. Some suggestions have focused on using the OCI index to add content, where a new OCI index is the new reference. This implies the user must change the reference to the `web:a2b2` image they intend to deploy.
+We have been largely focusing on the need to support this downward reference model.
+Some suggestions have focused on using the OCI index to add content, where a new OCI index is the new reference.
+This implies the user must change the reference to the `web:a2b2` image they intend to deploy.
 
 ## OCI index, downward reference of manifest
 
@@ -128,7 +151,7 @@ The artifact can be pulled as `registry.contoso.com/marketing/web:a2b2`
 }
 ```
 
-### `web:a2b2` signature with oci index:
+### `web:a2b2` signature with oci index
 
 When signing an existing artifact with this model, a new index would either need to be pushed, redirecting the `web:a2b2` tag to the new index, or the deployment would have to change to a new tag associated with the new index.
 
@@ -157,7 +180,8 @@ When signing an existing artifact with this model, a new index would either need
 }
 ```
 
-One challenge with this downward dependency approach is existing deployment documents which reference the original tag (`registry.contoso.com/marketing/web:a2b2`) and/or digest would need to change to the signed index reference (`registry.contoso.com/marketing/web:a2b2-verification`). This puts a new burden on a team that must change the references because another system may require a specific verification.
+One challenge with this downward dependency approach is existing deployment documents which reference the original tag (`registry.contoso.com/marketing/web:a2b2`) and/or digest would need to change to the signed index reference (`registry.contoso.com/marketing/web:a2b2-verification`).
+This puts a new burden on a team that must change the references because another system may require a specific verification.
 
 Updating the existing tag could cause inconsistencies as some verification systems track the digest associated with a tag, and also limits new signatures from being pushed, without having to update the same index.
 
@@ -165,7 +189,7 @@ Updating the existing tag could cause inconsistencies as some verification syste
 
 **What if** we supported a reverse lookup, where a client can ask for all the verification objects for a given artifact? Reverse lookup refers to the ability to find which manifests are referenced by index objects.
 
-![](./media/oci-manifest-index-reverse-lookup.png)
+![Two notary artifacts refering a single image](./media/oci-manifest-index-reverse-lookup.png)
 
 We could still use the oci index schema with two changes:
 
@@ -201,8 +225,10 @@ Same as above.
 
 ### web:a2b2 staging verification w/ index
 
-An index is pushed that supports `index.config`, which tells the registry this index is a type of Notary Verification. This follows the same pattern we use with [OCI Artifacts to identify oci manifest as specific type](https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md#defining-oci-artifact-types).
-This index would NOT be pushed with a tag. It would be a digest only reference. 
+An index is pushed that supports `index.config`, which tells the registry this index is a type of Notary Verification.
+This follows the same pattern we use with [OCI Artifacts to identify oci manifest as specific type](https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md#defining-oci-artifact-types).
+This index would NOT be pushed with a tag.
+It would be a digest only reference.
 
 ```json
 {
@@ -292,7 +318,8 @@ nv2 verify registry.contoso.com/marketing/web:a2b2
 nv2 verify registry.contoso.com/marketing/web@256:efg123
 ```
 
-The `nv2 verify` API compares the artifact with local configuration to attest to it matching the configured rules. These could include the artifact has required verifications for Scanning and Testing verification.
+The `nv2 verify` API compares the artifact with local configuration to attest to it matching the configured rules.
+These could include the artifact has required verifications for Scanning and Testing verification.
 
 ## Pros & Cons
 
@@ -303,23 +330,32 @@ The pros of this approach are:
 
 The cons of this approach:
 
-- A new API must be added. We’ve said this was within scope and ok as registries must add Notary v1, Content Trust to support existing scenarios. Since most registries need to do some work, adding a new API is not a stretch
-- Reverse lookup, and its impact on garbage collection. Registries tend to traverse down. If multiple manifests reference common base layers, the registry knows to reference count shared layers and only deletes the layers once all manifests are removed. Orphaned manifests may be deleted if they’re no longer referenced by tags.  
-Most importantly, a manifest is likely blocked from deletion if it’s referenced by an index. In this reverse lookup model, the user likely wants all verifications to be deleted when the artifact is deleted. This isn’t necessarily an immediate blocker, but it does go against the garbage collection constraint outlined above.
-This is work registry operators must implement so users don’t have to change their artifact references? Is this the right trade-off?
+- A new API must be added.
+  We’ve said this was within scope and ok as registries must add Notary v1, Content Trust to support existing scenarios.
+  Since most registries need to do some work, adding a new API is not a stretch
+- Reverse lookup, and its impact on garbage collection.
+  Registries tend to traverse down.
+  If multiple manifests reference common base layers, the registry knows to reference count shared layers and only deletes the layers once all manifests are removed.
+  Orphaned manifests may be deleted if they’re no longer referenced by tags.
+  Most importantly, a manifest is likely blocked from deletion if it’s referenced by an index.
+  In this reverse lookup model, the user likely wants all verifications to be deleted when the artifact is deleted.
+  This isn’t necessarily an immediate blocker, but it does go against the garbage collection constraint outlined above.
+  This is work registry operators must implement so users don’t have to change their artifact references? Is this the right trade-off?
 
 ## Verifications with Additional Content
 
-We’ve debated whether a signature is the verification, or something more must be provided. For instance, should some TUF metadata or an SBoM be required as well?
+We’ve debated whether a signature is the verification, or something more must be provided.
+For instance, should some TUF metadata or an SBoM be required as well?
 The reverse lookup index could be expanded as follows:
 
-![](./media/oci-manifest-index-reverse-lookup-sbom.png)
+![Multi-platform manifest with SBoM, TUF, and Scan artifacts](./media/oci-manifest-index-reverse-lookup-sbom.png)
 
 The user still references `registry.contoso.com/web:a2b2`, while other parts of the system that adhere to notary v2 would know to query the registry for the additional verification information.
 
 An nv2 client queries for all indexes with a `"config.mediaType"` of `"application/vnd.cncf.notary.verification.config.v1+json"` It would read all the verification objects and decide how to proceed.
 
-For customers that aren’t comfortable with tags, you could query for the digest of `web:a2b2`. It would return the same list of verification objects.
+For customers that aren’t comfortable with tags, you could query for the digest of `web:a2b2`.
+It would return the same list of verification objects.
 
 ```bash
 nv2 verify registry.contoso.com/web@sha256:efg123
@@ -327,5 +363,5 @@ nv2 verify registry.contoso.com/web@sha256:efg123
 
 The SBOM client would know to parse the index and pull any manifests with a `"config.mediaType"` of `"application/foo.sbom.config.v1+json"`.
 The tuf enabled client would know to pull a `"config.mediaType"` of `"application/cncf.tuf.config.v1+json"`
-A cloud specific extension would know to pull a `"config.mediaType"` of `"application/azure.securitycenter.config.v1+json"` verifying it was recently scanned before proceeding. If the scan was too old, it may block deployment while a new scan is achieved, or enable deployment with a scan occurring concurrently.
-
+A cloud specific extension would know to pull a `"config.mediaType"` of `"application/azure.securitycenter.config.v1+json"` verifying it was recently scanned before proceeding.
+If the scan was too old, it may block deployment while a new scan is achieved, or enable deployment with a scan occurring concurrently.


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

This is cleaning up a bunch of linting warnings that were bugging me:

- linefeed between heading and sections
- using `-` for all unordered list for consistency
- using `1. ` for all ordered list entries to allow easier insertion to the middle of a list
- one sentence per line for easier PRs
- headings without a trailing `:` or other punctuation
- alt-text for images
- specifying syntax for each code block
- removing trailing whitespace
- probably something else I'm forgetting