### PR TITLE
Adding scope to trust policy.

### DIFF
--- a/trust-store-trust-policy-specification.md
+++ b/trust-store-trust-policy-specification.md
@@ -135,7 +135,7 @@ Property descriptions
 - **`version`**(*string*): This REQUIRED property is the version of the trust policy. The supported value is `1.0`.
 - **`trustPolicies`**(*string-array of objects map*): This REQUIRED property represents a collection of trust policies.
   - **`name`**(*string*): The name of the trust policy.
-  - **`scope`**(*string*): The scope determines which trust policy is applicable for a given artifact. The scope field supports prefix-based filtering on `registry-name/namespace+repository-name`. For an artifact there if there is no applicable trust policy, then the signature evaluation must be skipped, this is required to support gradual rollout signature validation.
+  - **`scope`**(*string*): The scope determines which trust policy is applicable for a given artifact. The scope field supports prefix-based filtering on registry-name/namespace+repository-name. For an artifact, if there is no applicable trust policy, then signature evaluation must be skipped.
   Please see [Scope Constraints](#scope_constraints) for more details.
   - **`trustStores`**(*array of strings*): This REQUIRED property specifies a list of names of trust stores that the user trusts.
   - **`expiryValidations`**(*object*): This REQUIRED property represents a collection of artifact expiry-related validations.
@@ -173,7 +173,7 @@ Precondition: The artifact is signed, trust store and trust policies are present
 1. Get the public key from the signing identity and validate the artifact integrity using the public key and signing algorithm identified in the previous step.
 1. Get and validate TrustStore and TrustPolicy for correctness.
 1. Find the trust policy that is applicable for the given artifact. If there is no applicable trust policy, then the signature evaluation must be skipped.
-1. Get the signing identity from the signed artifact and validate it against the identities configured in the trust store of trust policy determined in step 3. The signing identity must match or lead to at least one of the trusted identities configured in the trust store.
+1. Get the signing identity from the signed artifact and validate it against the identities configured in the trust store of trust policy determined in step 4. The signing identity must match or lead to at least one of the trusted identities configured in the trust store.
     1. If signing identity is certificate then validate that the certificate and certificate-chain leads to self-signed root.
 1. Perform [artifact expiry](#artifact-expiry) validations based on trust policy.
 1. Perform [artifact revocation](#artifact-revocation) validations based on trust policy

--- a/trust-store-trust-policy-specification.md
+++ b/trust-store-trust-policy-specification.md
@@ -117,7 +117,7 @@ The trust policy is represented as JSON data structure as shown below:
         {
             "name": "skip-signature-verification",
             "scopes": [ "wabbit-networks.io/software/unsigned/productA" ],
-            "skipValidations": true,
+            "skipSignatureVerification": true,
         },
         {
             "name": "global-trust-policy",
@@ -144,7 +144,7 @@ Property descriptions
 - **`trustPolicies`**(*string-array of objects map*): This REQUIRED property represents a collection of trust policies.
   - **`name`**(*string*): This REQUIRED propert represents name of the trust policy.
   - **`scopes`**(*array of strings*): This REQUIRED property determines which trust policy is applicable for the given artifact. The scope field supports filtering based on fully qualified repository URI `${registry-name}/${namespace}/${repository-name}`. For more information, see [scopes constraints](#scope-constraints) section.
-  - **`skipValidations`**(*boolean*): This OPTIONAL property dictates whether Notary v2 should skip signature validations or not. If set to `true` Notary v2 MUST NOT perform any signature validations including the custom validations performed using plugins. This is required to support the gradual rollout of signature validation i.e the case when the user application has a mix of signed and unsigned artifacts. When set to `false`, the following properties  MUST be present `trustStores`, `expiryValidations`, `revocationValidations`. The default value is `false`.
+  - **`skipSignatureVerification`**(*boolean*): This OPTIONAL property dictates whether Notary v2 should skip signature verification or not. If set to `true` Notary v2 MUST NOT perform any signature validations including the custom validations performed using plugins. This is required to support the gradual rollout of signature validation i.e the case when the user application has a mix of signed and unsigned artifacts. When set to `false`, the following properties  MUST be present `trustStores`, `expiryValidations`, `revocationValidations`. The default value is `false`.
   - **`trustStores`**(*array of strings*): This OPTIONAL property specifies a list of names of trust stores that the user trusts.
   - **`expiryValidations`**(*object*): This OPTIONAL property represents a collection of artifact expiry-related validations.
     - **`signatureExpiry`**(*string*): This REQUIRED property specifies what implementation must do if the signature is expired.  Supported values are `enforce` and `warn`.
@@ -185,7 +185,7 @@ Precondition: The artifact is signed, trust store and trust policies are present
 1. Get the signing algorithm (hash+encryption) from the signing identity and validate that the signing algorithm is valid and allow-listed.
 1. Get the public key from the signing identity and validate the artifact integrity using the public key and signing algorithm identified in the previous step.
 1. Get and validate TrustStore and TrustPolicy for correctness.
-1. Find the trust policy that is applicable for the given artifact. In the trust policy if `skipValidations` is set to `true`, then the signature evaluation must be skipped.
+1. Find the trust policy that is applicable for the given artifact. In the trust policy if `skipSignatureVerification` is set to `true`, then the signature evaluation must be skipped.
 1. Get the signing identity from the signed artifact and validate it against the identities configured in the trust store of trust policy determined in step 4. The signing identity must match or lead to at least one of the trusted identities configured in the trust store.
     1. If signing identity is certificate then validate that the certificate and certificate-chain leads to self-signed root.
 1. Perform [artifact expiry](#artifact-expiry) validations based on trust policy.
@@ -200,7 +200,7 @@ Here is high level uml diagram for signature evaluation:
 
 **Q: How should multiple signatures requirements be represented in the trust policy?**
 
-**A:** Noltary v2 doesn't support n out m signature requirement verification scheme. Validation succeeds if verification succeeds for at least one signature.
+**A:** Notary v2 doesn't support n out m signature requirement verification scheme. Validation succeeds if verification succeeds for at least one signature.
 
 **Q: Should local revocation and TSA servers be listed in the trust policy to support disconnected environments?**
 

--- a/trust-store-trust-policy-specification.md
+++ b/trust-store-trust-policy-specification.md
@@ -157,7 +157,7 @@ Value descriptions
 #### Scope Constraints
 
 - There MUST NOT be two trust policies with the same scope.
-- There MUST be only one trust policy applicable to an artifact. In the case of overlapping scopes, the longest prefix match rule is used.  For example, the `wabbit-networks.io/software/dotnet/ocp-release` image if there are two trust policies with overlapping scopes `registry.wabbit-networks.io/software` and `registery.wabbit-networks.io/software/dotnet` then the policy with the longest-prefix matching scope i.e. `registery.wabbit-networks.io/software/dotnet` will be used for signature evaluation.
+- There MUST be only one trust policy applicable to an artifact. In the case of overlapping scopes, the longest prefix match rule is used.  For example, the `wabbit-networks.io/software/dotnet/ocp-release` image if there are two trust policies with overlapping scopes `registry.wabbit-networks.io/software` and `registry.wabbit-networks.io/software/dotnet` then the policy with the longest-prefix matching scope i.e. `registry.wabbit-networks.io/software/dotnet` will be used for signature evaluation.
 - There MUST only be only one trust policy without the `scope` key, which means that the trust policy has global scope(applicable to all artifacts). The trust policy without the `scope` key is optional.
 
 ### Extended Validation

--- a/trust-store-trust-policy-specification.md
+++ b/trust-store-trust-policy-specification.md
@@ -164,9 +164,10 @@ Value descriptions
 
 #### Scopes Constraints
 
-- Trust policy MUST have a scope property and the scope collection MUST contain at least one value.
-- The scope MUST contain a fully qualified URI of the repository. The repository URI MUST NOT contain asterisk character `*`.
-- Optionally, there can be one trust policy with scope collection containing only asterisk(s) character `*` as the value. The scope with `*` value is called global scope. The trust policy with global scope applies to all the artifacts.
+- Each trust policy MUST contain scope property and the scope collection MUST contain at least one value.
+- The scope MUST contain one of the following:
+  - List of one or more fully qualified repository URIs. The repository URI MUST NOT contain the asterisk character `*`.
+  - A single value with one asterisk character `*`. The scope with `*` value is called global scope. The trust policy with global scope applies to all the artifacts. There can only be one trust policy that uses a global scope.
 - For a given artifact there MUST be only one applicable trust policy, with the exception of trust policy with global scope.
 - For a given artifact, if there is no applicable trust policy then Notary v2 MUST consider the artifact as untrusted and fail signature verification.
 - The scope MUST NOT support reference expansion i.e. URIs must be fully qualified. E.g. the scope should be `docker.io/library/registry` rather than `registry`.

--- a/trust-store-trust-policy-specification.md
+++ b/trust-store-trust-policy-specification.md
@@ -156,10 +156,10 @@ Value descriptions
 
 #### Scope Constraints
 
-- There MUST only be  one trust policy applicable to a artifact.
+- There MUST only be one trust policy applicable to an artifact.
 - There MUST not be two trust policies with the same scope.
 - There MUST only be only one trust policy without the `scope` key, which means that the trust policy has global scope(applicable to all artifacts).In the case of overlapping scopes, the longest prefix match rule is used.  For example, the `wabbit-networks.io/software/dotnet/ocp-release` image if there are two trust policies with overlapping scopes `registry.wabbit-networks.io/software` and `registery.wabbit-networks.io/software/dotnet` then the policy with the longest-prefix matching scope i.e. `registery.wabbit-networks.io/software/dotnet` will be used for signature evaluation.
-- The turst policy without the `scope` key is optional.
+- The trust policy without the `scope` key is optional.
 
 ### Extended Validation
 

--- a/trust-store-trust-policy-specification.md
+++ b/trust-store-trust-policy-specification.md
@@ -135,7 +135,7 @@ Property descriptions
 - **`version`**(*string*): This REQUIRED property is the version of the trust policy. The supported value is `1.0`.
 - **`trustPolicies`**(*string-array of objects map*): This REQUIRED property represents a collection of trust policies.
   - **`name`**(*string*): The name of the trust policy.
-  - **`scope`**(*string*): The scope determines which trust policy is applicable for a given artifact. The scope field supports prefix-based filtering on registry-name/namespace+repository-name. For an artifact, if there is no applicable trust policy, then signature evaluation must be skipped.
+  - **`scope`**(*array of string*): The scope determines which trust policy is applicable for a given artifact. The scope field supports array of prefix-based filtering on registry-name/namespace+repository-name. For an artifact, if there is no applicable trust policy, then signature evaluation must be skipped.
   Please see [Scope Constraints](#scope_constraints) for more details.
   - **`trustStores`**(*array of strings*): This REQUIRED property specifies a list of names of trust stores that the user trusts.
   - **`expiryValidations`**(*object*): This REQUIRED property represents a collection of artifact expiry-related validations.
@@ -156,10 +156,9 @@ Value descriptions
 
 #### Scope Constraints
 
-- There MUST only be one trust policy applicable to an artifact.
-- There MUST not be two trust policies with the same scope.
-- There MUST only be only one trust policy without the `scope` key, which means that the trust policy has global scope(applicable to all artifacts).In the case of overlapping scopes, the longest prefix match rule is used.  For example, the `wabbit-networks.io/software/dotnet/ocp-release` image if there are two trust policies with overlapping scopes `registry.wabbit-networks.io/software` and `registery.wabbit-networks.io/software/dotnet` then the policy with the longest-prefix matching scope i.e. `registery.wabbit-networks.io/software/dotnet` will be used for signature evaluation.
-- The trust policy without the `scope` key is optional.
+- There MUST NOT be two trust policies with the same scope.
+- There MUST be only one trust policy applicable to an artifact. In the case of overlapping scopes, the longest prefix match rule is used.  For example, the `wabbit-networks.io/software/dotnet/ocp-release` image if there are two trust policies with overlapping scopes `registry.wabbit-networks.io/software` and `registery.wabbit-networks.io/software/dotnet` then the policy with the longest-prefix matching scope i.e. `registery.wabbit-networks.io/software/dotnet` will be used for signature evaluation.
+- There MUST only be only one trust policy without the `scope` key, which means that the trust policy has global scope(applicable to all artifacts). The trust policy without the `scope` key is optional.
 
 ### Extended Validation
 

--- a/trust-store-trust-policy-specification.md
+++ b/trust-store-trust-policy-specification.md
@@ -105,13 +105,13 @@ The trust policy is represented as JSON data structure as shown below:
                 "wabbit-networks.io/software/product2" ],
             "trustStores": [ "trust-store-name-1", "trust-store-name-2" ],
             "expiryValidations": {
-                "signatureExpiry": "enforce" | "warn",
-                "signingIdentityExpiry": "enforce" | "warn",
-                "timestampExpiry": "enforce" | "warn"
+                "signatureExpiry": "enforce | warn",
+                "signingIdentityExpiry": "enforce | warn",
+                "timestampExpiry": "enforce | warn"
             },
             "revocationValidations": {
-                "signingIdentityRevocation": "enforceWithFailOpen" | "enforceWithFailClose" | "warn" | "skip",
-                "timestampRevocation": "enforceWithFailOpen" | "enforceWithFailClose"| "warn" | "skip"
+                "signingIdentityRevocation": "enforceWithFailOpen | enforceWithFailClose | warn | skip",
+                "timestampRevocation": "enforceWithFailOpen | enforceWithFailClose | warn | skip"
             }
         },
         {
@@ -124,13 +124,13 @@ The trust policy is represented as JSON data structure as shown below:
             "scopes": [ "*" ],
             "trustStores": [ "trust-store-name-1", "trust-store-name-2" ],
             "expiryValidations": {
-                "signatureExpiry": "enforce" | "warn",
-                "signingIdentityExpiry": "enforce" | "warn",
-                "timestampExpiry": "enforce" | "warn"
+                "signatureExpiry": "enforce | warn",
+                "signingIdentityExpiry": "enforce | warn",
+                "timestampExpiry": "enforce | warn"
             },
             "revocationValidations": {
-                "signingIdentityRevocation": "enforceWithFailOpen" | "enforceWithFailClose" | "warn" | "skip",
-                "timestampRevocation": "enforceWithFailOpen" | "enforceWithFailClose"| "warn" | "skip"
+                "signingIdentityRevocation": "enforceWithFailOpen | enforceWithFailClose | warn | skip",
+                "timestampRevocation": "enforceWithFailOpen | enforceWithFailClose | warn | skip"
             }
         }
 
@@ -185,7 +185,7 @@ Precondition: The artifact is signed, trust store and trust policies are present
 1. Get the signing algorithm (hash+encryption) from the signing identity and validate that the signing algorithm is valid and allow-listed.
 1. Get the public key from the signing identity and validate the artifact integrity using the public key and signing algorithm identified in the previous step.
 1. Get and validate TrustStore and TrustPolicy for correctness.
-1. Find the trust policy that is applicable for the given artifact. If there is no applicable trust policy, then the signature evaluation must be skipped.
+1. Find the trust policy that is applicable for the given artifact. In the trust policy if `skipValidations` is set to `true`, then the signature evaluation must be skipped.
 1. Get the signing identity from the signed artifact and validate it against the identities configured in the trust store of trust policy determined in step 4. The signing identity must match or lead to at least one of the trusted identities configured in the trust store.
     1. If signing identity is certificate then validate that the certificate and certificate-chain leads to self-signed root.
 1. Perform [artifact expiry](#artifact-expiry) validations based on trust policy.

--- a/trust-store-trust-policy-specification.md
+++ b/trust-store-trust-policy-specification.md
@@ -168,10 +168,7 @@ Value descriptions
     - `wabbit-networks.io/software`
 - There MUST be only one trust policy applicable to an artifact. In the case of overlapping scopes, the following steps should be used to evaluate the priority
     1. Respoitory scope i.e. exact match of repository URI has the highest priority
-    2. In the case of more than one matching namespace scopes, the scope with the longest namespace match takes priority over other namespace scopes. 
-
-    For example, in the case of the `wabbit-networks.io/software/ocp-release` repository, the priority order of matching scope is
-    `wabbit-networks.io/software/ocp-release` > `wabbit-networks.io/software/` > `wabbit-networks.io/`.
+    2. In the case of more than one matching namespace scopes, the scope with the longest namespace match takes priority over other namespace scopes.For example, in the case of the `wabbit-networks.io/software/ocp-release` repository, the priority order of matching scope is `wabbit-networks.io/software/ocp-release` > `wabbit-networks.io/software/` > `wabbit-networks.io/`.
 - Two trust policies MUST NOT have the same scope.
 - Optionally, there can be one trust policy without scope. The trust policy without scope applies to all artifacts.
 - The scope MUST NOT support reference expansion i.e. URIs must be explicit. E.g. the scope should be `docker.io/library/registry` rather than `registry`.
@@ -184,7 +181,7 @@ The implementation must allow the user to execute custom validations. These cust
 
 Precondition: The artifact is signed, trust store and trust policies are present.
 
-1. Get the signing algorithm(hash+encryption) from the signing identity and validate that the signing algorithm is valid and allow-listed.
+1. Get the signing algorithm (hash+encryption) from the signing identity and validate that the signing algorithm is valid and allow-listed.
 1. Get the public key from the signing identity and validate the artifact integrity using the public key and signing algorithm identified in the previous step.
 1. Get and validate TrustStore and TrustPolicy for correctness.
 1. Find the trust policy that is applicable for the given artifact. If there is no applicable trust policy, then the signature evaluation must be skipped.
@@ -202,13 +199,13 @@ Here is high level uml diagram for signature evaluation:
 
 **Q: How should multiple signatures requirements be represented in the trust policy?**
 
-**A:** We don't support n out m signature requirement verification scheme. Validation succeeds if verification succeeds for at least one signature.
+**A:** Noltary v2 doesn't support n out m signature requirement verification scheme. Validation succeeds if verification succeeds for at least one signature.
 
-**Q: Should local revocation and TSA servers are listed in the trust policy to support disconnected environments?**
+**Q: Should local revocation and TSA servers be listed in the trust policy to support disconnected environments?**
 
 **A:** Not natively supported but a user can configure `revocationValidations` to `skip` and then use extended validations to check for revocation.
 
-**Q: Why do we need to include a complete certificate chain(leading to root) in the signature?**
+**Q: Why do we need to include a complete certificate chain (leading to root) in the signature?**
 
 **A:** Without a complete certificate chain, the implementation won't be able to perform an exhaustive revocation check, which will lead to security issues, and that's the reason for enforcing a complete certificate chain.
 


### PR DESCRIPTION
##### Change Log
* **Latest:** Only perform exact repository URI match and use `*` for global scope. Also introduced `skipSignatureVerification` param. This removes complexity and simplifies the trust policy. Also, in the future, we can always add wildcard support if required.
* **version |||:** Use `*` for namespace matching and `**` for nested namespace matching. 
* **version ||:** Use the longest prefix-based scoping but restrict it to namespace or complete repository URI match.
* **version I:** Use the longest prefix-based scoping.

As per discussion in https://github.com/notaryproject/notaryproject/discussions/98,  added longest prefix match-based scoping.