### PR TITLE
COSE Signature Envelope

### DIFF
--- a/signature-specification.md
+++ b/signature-specification.md
@@ -149,8 +149,8 @@ Note: The above example is represented using the [extended CBOR diagnostic notat
 - **`crit`** (*array of integers or strings*): This REQUIRED property (label: `2`) lists the headers that implementation MUST understand and process.
   The array MUST contain `3` (`cty`), and `signingtime`. If `expiry` is presented, the array MUST also contain `expiry`.
 - **`cty`** (*string*): The REQUIRED property content-type (label: `3`) is used to declare the media type of the secured content (the payload).
-- **`signingtime`** (*integer* or tagged *datetime*): The REQUIRED property identifies the time at which the signature was generated.
-- **`expiry`** (*integer* or tagged *datetime*): This OPTIONAL property contains the expiration time on or after which the signature must not be considered valid.
+- **`signingtime`** (*datetime*): The REQUIRED property identifies the time at which the signature was generated.
+- **`expiry`** (*datetime*): This OPTIONAL property contains the expiration time on or after which the signature must not be considered valid.
 
 **UnprotectedHeaders**: Notary v2 supports two unprotected headers: `timestamp` and `x5chain`.
 

--- a/signature-specification.md
+++ b/signature-specification.md
@@ -17,7 +17,7 @@ The signature manifest has an artifact type that specifies it's a Notary V2 sign
 
 - **`artifactType`** (*string*): This REQUIRED property references the Notary version of the signature: `application/vnd.cncf.notary.v2.signature`.
 - **`blobs`** (*array of objects*): This REQUIRED property contains collection of only one [artifact descriptor](https://github.com/oras-project/artifacts-spec/blob/main/descriptor.md) referencing signature envelope.
-  - **`mediaType`** (*string*): This REQUIRED property contains media type of signature envelope blob. The supported value are `application/jose+json` and `application/cose`.
+  - **`mediaType`** (*string*): This REQUIRED property contains media type of signature envelope blob. The supported value is `application/cose`.
 - **`subject`** (*descriptor*): A REQUIRED artifact descriptor referencing the signed manifest, including, but not limited to image manifest, image index, oras-artifact manifest.
 - **`annotations`** (*string-string map*): This REQUIRED property contains metadata for the artifact manifest.
   It is being used to store information about the signature.
@@ -70,7 +70,7 @@ A signature envelope consists of the following components:
 
 A signature envelope is `e = {m, v, u, s}` where `s` is signature.
 
-Notary v2 supports [JWS JSON Serialization](https://datatracker.ietf.org/doc/html/rfc7515) and [COSE_Sign1_Tagged](https://datatracker.ietf.org/doc/html/rfc8152#section-4) as signature envelope formats with some additional constraints but makes provisions to support additional signature envelope format.
+Notary v2 supports [COSE_Sign1_Tagged](https://datatracker.ietf.org/doc/html/rfc8152#section-4) as signature envelope format with some additional constraints but makes provisions to support additional signature envelope format.
 
 ### Payload
 
@@ -80,9 +80,7 @@ Notary v2 requires Payload to be the content **descriptor** of the subject manif
 1. Descriptor MAY contain `annotations` and if present it MUST follow the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules). Notary v2 uses annotations for storing both Notary specific and user defined signed attributes. The prefix `org.cncf.notary` in annotation keys is reserved for use in Notary v2 and MUST NOT be used outside this specification.
 1. Descriptor MAY contain `artifactType` field for artifact manifests, or the `config.mediaType` for `oci.image` based manifests.
 
-#### JSON Examples
-
-The media type of the content descriptor is `application/vnd.cncf.oras.artifact.descriptor.v1+json`.
+Examples: The media type of the content descriptor is `application/vnd.cncf.oras.artifact.descriptor.v1+json`.
 
 ```jsonc
 {
@@ -101,58 +99,6 @@ The media type of the content descriptor is `application/vnd.cncf.oras.artifact.
    "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",
    "size": 32654
 }
-```
-
-#### CBOR Examples
-
-The media type of the content descriptor is `application/vnd.cncf.oras.artifact.descriptor.v1+cbor`.
-
-```sql
-a4 -- Map of size 4
-   69       -- Key:   UTF-8 text: 9 bytes
-      6d 65 64 69 61 54 79 70 65                      -- mediaType
-   78 2a    -- Value: UTF-8 text: 42 bytes
-      61 70 70 6c 69 63 61 74 69 6f 6e 2f 76 6e 64 2e -- application/vnd.
-      6f 63 69 2e 69 6d 61 67 65 2e 6d 61 6e 69 66 65 -- oci.image.manife
-      73 74 2e 76 31 2b 6a 73 6f 6e                   -- st.v1+json
-   66       -- Key:   UTF-8 text: 6 bytes
-      64 69 67 65 73 74                               -- digest
-   78 47    -- Value: UTF-8 text: 71 bytes
-      73 68 61 32 35 36 3a 37 33 63 38 30 33 39 33 30 -- sha256:73c803930
-      65 61 33 62 61 31 65 35 34 62 63 32 35 63 32 62 -- ea3ba1e54bc25c2b
-      64 63 35 33 65 64 64 30 32 38 34 63 36 32 65 64 -- dc53edd0284c62ed
-      36 35 31 66 65 37 62 30 30 33 36 39 64 61 35 31 -- 651fe7b00369da51
-      39 61 33 63 33 33 33                            -- 9a3c333
-   64       -- Key:   UTF-8 text: 4 bytes
-      73 69 7a 65                                     -- size
-   19 41 54 -- Value: Integer: 16724
-   6b       -- Key:   UTF-8 text: 11 bytes
-      61 6e 6e 6f 74 61 74 69 6f 6e 73                -- annotations
-   a1 -- Value: Map of size 1
-      78 1a    -- Key:   UTF-8 text: 26 bytes
-         69 6f 2e 77 61 62 62 69 74 2d 6e 65 74 77 6f 72 -- io.wabbit-networ
-         6b 73 2e 62 75 69 6c 64 49 64                   -- ks.buildId
-      63       -- Value: UTF-8 text: 3 bytes
-         31 32 33                                        -- 123
-```
-
-```sql
-a3 -- Map of size 3
-   69       -- Key:   UTF-8 text: 9 bytes
-      6d 65 64 69 61 54 79 70 65                      -- mediaType
-   6c       -- Value: UTF-8 text: 12 bytes
-      73 62 6f 6d 2f 65 78 61 6d 70 6c 65             -- sbom/example
-   66       -- Key:   UTF-8 text: 6 bytes
-      64 69 67 65 73 74                               -- digest
-   78 47    -- Value: UTF-8 text: 71 bytes
-      73 68 61 32 35 36 3a 39 38 33 34 38 37 36 64 63 -- sha256:9834876dc
-      66 62 30 35 63 62 31 36 37 61 35 63 32 34 39 35 -- fb05cb167a5c2495
-      33 65 62 61 35 38 63 34 61 63 38 39 62 31 61 64 -- 3eba58c4ac89b1ad
-      66 35 37 66 32 38 66 32 66 39 64 30 39 61 66 31 -- f57f28f2f9d09af1
-      30 37 65 65 38 66 30                            -- 07ee8f0
-   64       -- Key:   UTF-8 text: 4 bytes
-      73 69 7a 65                                     -- size
-   19 7f 8e -- Value: Integer: 32654
 ```
 
 ### Signed Attributes

--- a/signature-specification.md
+++ b/signature-specification.md
@@ -70,7 +70,7 @@ A signature envelope consists of the following components:
 
 A signature envelope is `e = {m, v, u, s}` where `s` is signature.
 
-Notary v2 supports [JWS JSON Serialization](https://datatracker.ietf.org/doc/html/rfc7515) and [COSE_Sign1](https://datatracker.ietf.org/doc/html/rfc8152#section-4) as signature envelope formats with some additional constraints but makes provisions to support additional signature envelope format.
+Notary v2 supports [JWS JSON Serialization](https://datatracker.ietf.org/doc/html/rfc7515) and [COSE_Sign1_Tagged](https://datatracker.ietf.org/doc/html/rfc8152#section-4) as signature envelope formats with some additional constraints but makes provisions to support additional signature envelope format.
 
 ### Payload
 
@@ -248,8 +248,8 @@ To leverage JWS claims validation functionality already provided by libraries, w
 The process is described below:
 
 1. Compute the Base64Url value of ProtectedHeaders.
-2. Compute the Base64Url value of JWSPayload.
-3. Build message to be signed by concatenating the values generated in step 1 and step 2 using '.'
+1. Compute the Base64Url value of JWSPayload.
+1. Build message to be signed by concatenating the values generated in step 1 and step 2 using '.'
 `ASCII(BASE64URL(UTF8(ProtectedHeaders)) ‘.’ BASE64URL(JWSPayload))`
 1. Compute the signature on the message constructed in the previous step by using the signature algorithm defined in the corresponding header element: `alg`.
 1. Compute the Base64Url value of the signature produced in the previous step.
@@ -288,10 +288,10 @@ Since Notary v2 restricts one signature per signature envelope, the compliant si
 1. Only JWS JSON flattened format is supported.
    See 'Signature Envelope' section.
 
-#### COSE_Sign1
+#### COSE_Sign1_Tagged
 
 In COSE ([rfc8152](https://datatracker.ietf.org/doc/html/rfc8152)), data is stored as either payload or headers (protected and unprotected).
-Notary v2 uses [COSE_Sign1](https://datatracker.ietf.org/doc/html/rfc8152#section-4.2) object as the signature envelope with some additional constraints on the header fields.
+Notary v2 uses [COSE_Sign1_Tagged](https://datatracker.ietf.org/doc/html/rfc8152#section-4.2) object as the signature envelope with some additional constraints on the header fields.
 
 Unless explicitly specified as OPTIONAL, all fields are required.
 
@@ -373,7 +373,7 @@ The process is described below:
 1. Compute the signature on the `ToBeSigned` constructed in the previous step by using the signature algorithm defined in the corresponding header element: `alg`.
    This is the value of the signature property used in the signature envelope.
 
-**Signature Envelope**: The final signature envelope is a `COSE_Sign1` object, consisting of Payload, ProtectedHeaders, UnprotectedHeaders, and Signature.
+**Signature Envelope**: The final signature envelope is a `COSE_Sign1_Tagged` object, consisting of Payload, ProtectedHeaders, UnprotectedHeaders, and Signature.
 
 ```
 header_map = {
@@ -393,6 +393,8 @@ COSE_Sign1 = [
    payload : bstr,
    signature : bstr
 ]
+
+COSE_Sign1_Tagged = #6.18(COSE_Sign1)
 ```
 
 **Implementation Constraints**: Notary v2 implementation MUST enforce the following constraints on signature generation and verification:

--- a/signature-specification.md
+++ b/signature-specification.md
@@ -30,7 +30,7 @@ The signature manifest has an artifact type that specifies it's a Notary V2 sign
    "artifactType": "application/vnd.cncf.notary.v2.signature",
     "blobs": [
         {
-            "mediaType": "application/jose+json",
+            "mediaType": "application/cose",
             "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",
             "size": 32654
         }

--- a/signature-specification.md
+++ b/signature-specification.md
@@ -131,97 +131,92 @@ Unless explicitly specified as OPTIONAL, all fields are required.
 
 **ProtectedHeaders**: Notary v2 supports only the following protected headers:
 
-```sql
-a4 -- Map of size 4
-   02       -- Key:   Integer: 2    -- `cty`: content type
-   78 35    -- Value: UTF-8 text: 53 bytes
-      61 70 70 6c 69 63 61 74 69 6f 6e 2f 76 6e 64 2e -- application/vnd.
-      63 6e 63 66 2e 6f 72 61 73 2e 61 72 74 69 66 61 -- cncf.oras.artifa
-      63 74 2e 64 65 73 63 72 69 70 74 6f 72 2e 76 31 -- ct.descriptor.v1
-      2b 63 62 6f 72                                  -- +cbor
-   03       -- Key:   Integer: 3    -- `crit`: critical headers
-   82       -- Value: Array of length 2
-      02 -- Integer: 2  -- `cty`: content type
-      6b -- UTF-8 text: 11 bytes
-         73 69 67 6e 69 6e 67 74 69 6d 65                -- signingtime
-   6b       -- Key:   UTF-8 text: 11 bytes
-      73 69 67 6e 69 6e 67 74 69 6d 65                -- signingtime
-   1b 00 00 01 1f 71 fb 08 38 -- Value: Integer: 1234567891000
-   66       -- Key:   UTF-8 text: 6 bytes
-      65 78 70 69 72 79                               -- expiry
-   1b 00 00 01 1f 71 fb 08 43 -- Value: Integer: 1234567891011
+```
+{
+  / crit / 2: [
+    / cty / 3,
+    'signingtime',
+    'expiry'
+  ],
+  / cty / 3: 'application/vnd.cncf.oras.artifact.descriptor.v1+json',
+  'signingtime': 1234567891000,
+  'expiry': 1234567891011
+}
 ```
 
-- **`cty`** (*string*): The REQUIRED property content-type (label: `2`) is used to declare the media type of the secured content (the payload).
-- **`crit`** (*array of integers or strings*): This REQUIRED property (label: `3`) lists the headers that implementation MUST understand and process.
-  The array MUST contain `2` (`cty`), and `signingtime`. If `expiry` is presented, the array MUST also contain `expiry`.
+Note: The above example is represented using the [extended CBOR diagnostic notation](https://datatracker.ietf.org/doc/html/rfc8152#appendix-C).
+
+- **`crit`** (*array of integers or strings*): This REQUIRED property (label: `2`) lists the headers that implementation MUST understand and process.
+  The array MUST contain `3` (`cty`), and `signingtime`. If `expiry` is presented, the array MUST also contain `expiry`.
+- **`cty`** (*string*): The REQUIRED property content-type (label: `3`) is used to declare the media type of the secured content (the payload).
 - **`signingtime`** (*integer*): The REQUIRED property identifies the time at which the signature was generated.
 - **`expiry`** (*integer*): This OPTIONAL property contains the expiration time on or after which the signature must not be considered valid.
 
 **UnprotectedHeaders**: Notary v2 supports only two unprotected headers: `timestamp` and `x5chain`.
 
-```sql
-a2 -- Map of size 2
-   69       -- Key:   UTF-8 text: 9 bytes
-      74 69 6d 65 73 74 61 6d 70                      -- timestamp
-   4e       -- Value: Binary string: 14 bytes
-      54 69 6d 65 53 74 61 6d 70 54 6f 6b 65 6e       -- TimeStampToken
-   18 21    -- Key:   Integer: 33   -- `x5chain`
-   83       -- Value: Array of length 3
-      4d -- Binary string: 13 bytes
-         44 45 52 28 6c 65 61 66 43 65 72 74 29          -- DER(leafCert)
-      57 -- Binary string: 23 bytes
-         44 45 52 28 69 6e 74 65 72 6d 65 64 69 61 74 65 -- DER(intermediate
-         43 41 43 65 72 74 29                            -- CACert)
-      4d -- Binary string: 13 bytes
-         44 45 52 28 72 6f 6f 74 43 65 72 74 29          -- DER(rootCert)
+```
+{
+  'timestamp': << TimeStampToken >>,
+  / x5chain / 33: [
+    << DER(leafCert) >>,
+    << DER(intermediate CACert) >>,
+    << DER(rootCert) >>
+  ]
+}
 ```
 
-- **`timestamp`** (*binary string*): This OPTIONAL property is used to store time stamp token.
+Note: `<<` and `>>` are used to notate the byte string resulting from encoding the data item.
+
+- **`timestamp`** (*byte string*): This OPTIONAL property is used to store time stamp token.
   Only [RFC3161]([rfc3161](https://datatracker.ietf.org/doc/html/rfc3161#section-2.4.2)) compliant TimeStampToken are supported.
-- **`x5chain`** (*array of binary strings*): This REQUIRED property (label: `33` by [IANA](https://www.iana.org/assignments/cose/cose.xhtml#header-parameters)) contains the list of X.509 certificate or certificate chain ([RFC5280](https://datatracker.ietf.org/doc/html/rfc5280)) corresponding to the key used to digitally sign the COSE.
+- **`x5chain`** (*array of byte strings*): This REQUIRED property (label: `33` by [IANA](https://www.iana.org/assignments/cose/cose.xhtml#header-parameters)) contains the list of X.509 certificate or certificate chain ([RFC5280](https://datatracker.ietf.org/doc/html/rfc5280)) corresponding to the key used to digitally sign the COSE.
   The certificate containing the public key corresponding to the key used to digitally sign the COSE MUST be the first certificate.
   Optionally, this header can be presented in the protected header.
 
 **Signature**: In COSE, signature is calculated by constructing the `Sig_structure` for `COSE_Sign1`.
 The process is described below:
 
-1. Encode the protected header into a CBOR object as a binary string named `body_protected`.
+1. Encode the protected header into a CBOR object as a byte string named `body_protected`.
 2. Construct the `Sig_structure` for `COSE_Sign1`.
     ```
     Sig_structure = [
-        context : "Signature1",
-        body_protected : bstr,
-        external_aad : empty_bstr,
-        payload : bstr
+        / context / 'Signature1',
+        / body_protected / << ProtectedHeaders >>,
+        / external_aad / h'',
+        / payload / << Payload >>,
     ]
     ```
-3. Encode `Sig_structure` into a CBOR object as a binary string named `ToBeSigned`.
+3. Encode `Sig_structure` into a CBOR object as a byte string named `ToBeSigned`.
 4. Compute the signature on the `ToBeSigned` constructed in the previous step by using the signature algorithm defined in the corresponding header element: `alg`.
    This is the value of the signature property used in the signature envelope.
 
 **Signature Envelope**: The final signature envelope is a `COSE_Sign1_Tagged` object, consisting of Payload, ProtectedHeaders, UnprotectedHeaders, and Signature.
 
 ```
-header_map = {
-   * label => values
-}
-
-COSE_Sign1 = [
-   protected : bstr .cbor header_map,
-   unprotected : {
-       timestamp: TimeStampToken,
-       x5chain: [
-           leafCert,
-           intermediateCACert,
-           rootCert
-       ]
-   },
-   payload : bstr,
-   signature : bstr
-]
-
-COSE_Sign1_Tagged = #6.18(COSE_Sign1)
+18(
+  [
+    / protected / << {
+      / crit / 2: [
+        / cty / 3,
+        'signingtime',
+        'expiry'
+      ],
+      / cty / 3: 'application/vnd.cncf.oras.artifact.descriptor.v1+json',
+      'signingtime': 1234567891000,
+      'expiry': 1234567891011
+    } >>,
+    / unprotected / {
+      'timestamp': << TimeStampToken >>,
+      / x5chain / 33: [
+        << DER(leafCert) >>,
+        << DER(intermediate CACert) >>,
+        << DER(rootCert) >>
+      ]
+    },
+    / payload / << descriptor >>,
+    / signature / << sign( << Sig_structure >> ) >>
+  ]
+)
 ```
 
 ## Signature Algorithm Requirements

--- a/signature-specification.md
+++ b/signature-specification.md
@@ -17,7 +17,7 @@ The signature manifest has an artifact type that specifies it's a Notary V2 sign
 
 - **`artifactType`** (*string*): This REQUIRED property references the Notary version of the signature: `application/vnd.cncf.notary.v2.signature`.
 - **`blobs`** (*array of objects*): This REQUIRED property contains collection of only one [artifact descriptor](https://github.com/oras-project/artifacts-spec/blob/main/descriptor.md) referencing signature envelope.
-  - **`mediaType`** (*string*): This REQUIRED property contains media type of signature envelope blob. The supported value is `application/jose+json`
+  - **`mediaType`** (*string*): This REQUIRED property contains media type of signature envelope blob. The supported value are `application/jose+json` and `application/cose`.
 - **`subject`** (*descriptor*): A REQUIRED artifact descriptor referencing the signed manifest, including, but not limited to image manifest, image index, oras-artifact manifest.
 - **`annotations`** (*string-string map*): This REQUIRED property contains metadata for the artifact manifest.
   It is being used to store information about the signature.
@@ -70,7 +70,7 @@ A signature envelope consists of the following components:
 
 A signature envelope is `e = {m, v, u, s}` where `s` is signature.
 
-Notary v2 supports [JWS JSON Serialization](https://datatracker.ietf.org/doc/html/rfc7515) as signature envelope format with some additional constraints but makes provisions to support additional signature envelope format.
+Notary v2 supports [JWS JSON Serialization](https://datatracker.ietf.org/doc/html/rfc7515) and [COSE_Sign1](https://datatracker.ietf.org/doc/html/rfc8152#section-4) as signature envelope formats with some additional constraints but makes provisions to support additional signature envelope format.
 
 ### Payload
 
@@ -80,7 +80,9 @@ Notary v2 requires Payload to be the content **descriptor** of the subject manif
 1. Descriptor MAY contain `annotations` and if present it MUST follow the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules). Notary v2 uses annotations for storing both Notary specific and user defined signed attributes. The prefix `org.cncf.notary` in annotation keys is reserved for use in Notary v2 and MUST NOT be used outside this specification.
 1. Descriptor MAY contain `artifactType` field for artifact manifests, or the `config.mediaType` for `oci.image` based manifests.
 
-Examples:
+#### JSON Examples
+
+The media type of the content descriptor is `application/vnd.cncf.oras.artifact.descriptor.v1+json`.
 
 ```jsonc
 {
@@ -99,6 +101,58 @@ Examples:
    "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",
    "size": 32654
 }
+```
+
+#### CBOR Examples
+
+The media type of the content descriptor is `application/vnd.cncf.oras.artifact.descriptor.v1+cbor`.
+
+```sql
+a4 -- Map of size 4
+   69       -- Key:   UTF-8 text: 9 bytes
+      6d 65 64 69 61 54 79 70 65                      -- mediaType
+   78 2a    -- Value: UTF-8 text: 42 bytes
+      61 70 70 6c 69 63 61 74 69 6f 6e 2f 76 6e 64 2e -- application/vnd.
+      6f 63 69 2e 69 6d 61 67 65 2e 6d 61 6e 69 66 65 -- oci.image.manife
+      73 74 2e 76 31 2b 6a 73 6f 6e                   -- st.v1+json
+   66       -- Key:   UTF-8 text: 6 bytes
+      64 69 67 65 73 74                               -- digest
+   78 47    -- Value: UTF-8 text: 71 bytes
+      73 68 61 32 35 36 3a 37 33 63 38 30 33 39 33 30 -- sha256:73c803930
+      65 61 33 62 61 31 65 35 34 62 63 32 35 63 32 62 -- ea3ba1e54bc25c2b
+      64 63 35 33 65 64 64 30 32 38 34 63 36 32 65 64 -- dc53edd0284c62ed
+      36 35 31 66 65 37 62 30 30 33 36 39 64 61 35 31 -- 651fe7b00369da51
+      39 61 33 63 33 33 33                            -- 9a3c333
+   64       -- Key:   UTF-8 text: 4 bytes
+      73 69 7a 65                                     -- size
+   19 41 54 -- Value: Integer: 16724
+   6b       -- Key:   UTF-8 text: 11 bytes
+      61 6e 6e 6f 74 61 74 69 6f 6e 73                -- annotations
+   a1 -- Value: Map of size 1
+      78 1a    -- Key:   UTF-8 text: 26 bytes
+         69 6f 2e 77 61 62 62 69 74 2d 6e 65 74 77 6f 72 -- io.wabbit-networ
+         6b 73 2e 62 75 69 6c 64 49 64                   -- ks.buildId
+      63       -- Value: UTF-8 text: 3 bytes
+         31 32 33                                        -- 123
+```
+
+```sql
+a3 -- Map of size 3
+   69       -- Key:   UTF-8 text: 9 bytes
+      6d 65 64 69 61 54 79 70 65                      -- mediaType
+   6c       -- Value: UTF-8 text: 12 bytes
+      73 62 6f 6d 2f 65 78 61 6d 70 6c 65             -- sbom/example
+   66       -- Key:   UTF-8 text: 6 bytes
+      64 69 67 65 73 74                               -- digest
+   78 47    -- Value: UTF-8 text: 71 bytes
+      73 68 61 32 35 36 3a 39 38 33 34 38 37 36 64 63 -- sha256:9834876dc
+      66 62 30 35 63 62 31 36 37 61 35 63 32 34 39 35 -- fb05cb167a5c2495
+      33 65 62 61 35 38 63 34 61 63 38 39 62 31 61 64 -- 3eba58c4ac89b1ad
+      66 35 37 66 32 38 66 32 66 39 64 30 39 61 66 31 -- f57f28f2f9d09af1
+      30 37 65 65 38 66 30                            -- 07ee8f0
+   64       -- Key:   UTF-8 text: 4 bytes
+      73 69 7a 65                                     -- size
+   19 7f 8e -- Value: Integer: 32654
 ```
 
 ### Signed Attributes

--- a/signature-specification.md
+++ b/signature-specification.md
@@ -272,10 +272,10 @@ The **timestamping certificate** MUST meet the following minimum requirements:
 
 **Q: How will Notary v2 support multiple signature envelope format?**
 
-**A:** The idea is to use `mediaType` of artifact manifest's blob to identify the signature envelope type (like JWS, CMS, DSSE, etc).
+**A:** The idea is to use `mediaType` of artifact manifest's blob to identify the signature envelope type (like COSE, JWS, CMS, DSSE, etc).
 The client implementation can use the aforementioned `mediaType` to parse the signature envelope.
 
 **Q: How will Notary v2 handle non-backward compatible changes to signature format?**
 
 **A:** The Signature envelope MUST have a versioning mechanism to support non-backward compatible changes.
-For [JWS JSON serialization](#jws-json-serialization) signature envelope it is achieved by `cty` field in ProtectedHeaders.
+For [COSE_Sign1_Tagged](#cose_sign1_tagged) signature envelope it is achieved by `cty` field in ProtectedHeaders.

--- a/signature-specification.md
+++ b/signature-specification.md
@@ -227,14 +227,14 @@ Since Notary v2 restricts one signature per signature envelope, the compliant si
 1. `alg` header value MUST NOT be `none` or any symmetric-key algorithm such as `HMAC`.
 1. `alg` header value MUST be same as that of signature algorithm identified using signing certificate's public key algorithm and size.
 1. `alg` header values for various signature algorithms:
-  | Signature Algorithm             | `alg` Param Value |
-  | ------------------------------- | ----------------- |
-  | RSASSA-PSS with SHA-256         | PS256             |
-  | RSASSA-PSS with SHA-384         | PS384             |
-  | RSASSA-PSS with SHA-512         | PS512             |
-  | ECDSA on secp256r1 with SHA-256 | ES256             |
-  | ECDSA on secp384r1 with SHA-384 | ES384             |
-  | ECDSA on secp521r1 with SHA-512 | ES512             |
+    | Signature Algorithm             | `alg` Param Value |
+    | ------------------------------- | ----------------- |
+    | RSASSA-PSS with SHA-256         | PS256             |
+    | RSASSA-PSS with SHA-384         | PS384             |
+    | RSASSA-PSS with SHA-512         | PS512             |
+    | ECDSA on secp256r1 with SHA-256 | ES256             |
+    | ECDSA on secp384r1 with SHA-384 | ES384             |
+    | ECDSA on secp521r1 with SHA-512 | ES512             |
 1. Signing certificate MUST be a valid codesigning certificate.
 1. Only JWS JSON flattened format is supported.
    See 'Signature Envelope' section.

--- a/signature-specification.md
+++ b/signature-specification.md
@@ -127,9 +127,9 @@ Notary v2 uses [COSE_Sign1_Tagged](https://datatracker.ietf.org/doc/html/rfc8152
 
 Unless explicitly specified as OPTIONAL, all fields are required.
 
-**Payload**: COSE signs the payload as defined in the [Payload](#payload) section.
+**Payload**: COSE signs the payload as defined in the [Payload](#payload) section. Detached payloads are not supported.
 
-**ProtectedHeaders**: Notary v2 supports only the following protected headers:
+**ProtectedHeaders**: Notary v2 supports the following protected headers. Other header fields can be included but will be ignored.
 
 ```
 {
@@ -149,10 +149,10 @@ Note: The above example is represented using the [extended CBOR diagnostic notat
 - **`crit`** (*array of integers or strings*): This REQUIRED property (label: `2`) lists the headers that implementation MUST understand and process.
   The array MUST contain `3` (`cty`), and `signingtime`. If `expiry` is presented, the array MUST also contain `expiry`.
 - **`cty`** (*string*): The REQUIRED property content-type (label: `3`) is used to declare the media type of the secured content (the payload).
-- **`signingtime`** (*integer*): The REQUIRED property identifies the time at which the signature was generated.
-- **`expiry`** (*integer*): This OPTIONAL property contains the expiration time on or after which the signature must not be considered valid.
+- **`signingtime`** (*integer* or tagged *datetime*): The REQUIRED property identifies the time at which the signature was generated.
+- **`expiry`** (*integer* or tagged *datetime*): This OPTIONAL property contains the expiration time on or after which the signature must not be considered valid.
 
-**UnprotectedHeaders**: Notary v2 supports only two unprotected headers: `timestamp` and `x5chain`.
+**UnprotectedHeaders**: Notary v2 supports two unprotected headers: `timestamp` and `x5chain`.
 
 ```
 {


### PR DESCRIPTION
Replace JWS with COSE for the envelope format.

Highlight: Unlike JWS, `alg` is not a required header in COSE. Therefore, we can remove it completely, making the signature envelope more secure.

Resolves #117 