### PR TITLE
Update signature-envelope-cose.md

### DIFF
--- a/signature-envelope-cose.md
+++ b/signature-envelope-cose.md
@@ -47,8 +47,7 @@ Unless explicitly specified as OPTIONAL, all fields are required.
 
 Note: The above example is represented using the [extended CBOR diagnostic notation](https://datatracker.ietf.org/doc/html/rfc8152#appendix-C).
 
-- **`crit`** (*array of integers or strings*): This REQUIRED property (label: `2`) lists the headers that implementation MUST understand and process.
-  The array MUST contain `3` (`cty`), and `signingtime`. If `expiry` is presented, the array MUST also contain `expiry`.
+- **`crit`** (*array of integers or strings*): This OPTIONAL property (label: `2`) lists the headers that implementation MUST understand and process.
 - **`cty`** (*string*): The REQUIRED property content-type (label: `3`) is used to declare the media type of the secured content (the payload).
 - **`signingtime`** (*datetime*): The REQUIRED property identifies the time at which the signature was generated.
 - **`expiry`** (*datetime*): This OPTIONAL property contains the expiration time on or after which the signature must not be considered valid.


### PR DESCRIPTION
The `crit` header should be optional, not required. The spec already defines `cty` and `signingtime` as required, so a compliant verifier should reject any signature that does not include them, irrespective of whether or not the envelope also declares them as critical.

An appropriate use of `crit` would be if a signer intends to include a new header not defined in the spec, to instruct verifiers that they must understand and process that header in order for the signature to be successfully validated. Another scenario is if a signer intends to mandate processing of an otherwise optional header (e.g., `expiry`).

In other words, `crit` can be used by a signer to add requirements to the verification flow, but it is unnecessary and redundant if the verifier already has the same requirements.