### PR TITLE
Added describe-key command and pass-through plugin config

### DIFF
--- a/signature-specification.md
+++ b/signature-specification.md
@@ -225,18 +225,20 @@ Since Notary v2 restricts one signature per signature envelope, the compliant si
 **Implementation Constraints**: Notary v2 implementation MUST enforce the following constraints on signature generation and verification:
 
 1. `alg` header value MUST NOT be `none` or any symmetric-key algorithm such as `HMAC`.
-1. `alg` header value MUST be same as that of signature algorithm identified using signing certificate's public key algorithm and size.
-1. `alg` header values for various signature algorithms:
-  | Signature Algorithm             | `alg` Param Value |
-  | ------------------------------- | ----------------- |
-  | RSASSA-PSS with SHA-256         | PS256             |
-  | RSASSA-PSS with SHA-384         | PS384             |
-  | RSASSA-PSS with SHA-512         | PS512             |
-  | ECDSA on secp256r1 with SHA-256 | ES256             |
-  | ECDSA on secp384r1 with SHA-384 | ES384             |
-  | ECDSA on secp521r1 with SHA-512 | ES512             |
-1. Signing certificate MUST be a valid codesigning certificate.
-1. Only JWS JSON flattened format is supported.
+2. `alg` header value MUST be same as that of signature algorithm identified using signing certificate's public key algorithm and size.
+3. `alg` header values for various signature algorithms:
+
+| Signature Algorithm             | `alg` Param Value |
+| ------------------------------- | ----------------- |
+| RSASSA-PSS with SHA-256         | PS256             |
+| RSASSA-PSS with SHA-384         | PS384             |
+| RSASSA-PSS with SHA-512         | PS512             |
+| ECDSA on secp256r1 with SHA-256 | ES256             |
+| ECDSA on secp384r1 with SHA-384 | ES384             |
+| ECDSA on secp521r1 with SHA-512 | ES512             |
+
+4. Signing certificate MUST be a valid codesigning certificate.
+5. Only JWS JSON flattened format is supported.
    See 'Signature Envelope' section.
 
 ## Signature Algorithm Requirements

--- a/specs/plugin-extensibility.md
+++ b/specs/plugin-extensibility.md
@@ -73,7 +73,8 @@ List all valid plugins.
           "plugin": "com.example.nv2plugin",
           // Optional configuration as required by the plugin
           "pluginConfig" : {   
-            "key1" : "value1" 
+            "key1" : "value1",
+            "key 2" : "value 2"
           }
         }
     ]  
@@ -88,10 +89,13 @@ Plugins may require additional configuration to work correctly, that could be se
 * To use this feature, plugin authors MUST define and document the set of plugin configuration keys-values, which is set by users when they associate a plugin with signing key.
 * Plugin authors SHOULD NOT use plugin configuration to store sensitive configuration in plaintext, such as authentication keys used by the plugin etc.
 
-In the previous example, plugin config can be set using command line arguments as part of registring a key, or while signing using the key. Plugin config values provided by `notation sign` override values already set in `config.json` E.g.
+For the previous example, plugin config can be set using command line arguments as part of registering a key with the `notation key add` command. E.g.
 
-* `notation key add --name "mysigningkey" --id "keyid" --plugin "com.example.nv2plugin" --pluginConfig.key1 "value1"`
-* `notation sign $IMAGE --key "mysigningkey" --pluginConfig.key1 "value2"`
+* `notation key add --name "mysigningkey" --id "keyid" --plugin "com.example.nv2plugin" --pluginConfig key1=value1,"key 2"="value 2"`
+
+Plugin config can be also set/overriden during signing with the `notation sign` command. Following example overrides value for `key 2` already set in `config.json` by previous command.
+
+* `notation sign $IMAGE --key "mysigningkey" --pluginConfig "key 2"=newValue2`
 
 ### Plugin contract
 

--- a/specs/plugin-extensibility.md
+++ b/specs/plugin-extensibility.md
@@ -185,10 +185,10 @@ This interface targets plugins that integrate with providers of basic cryptograp
         2. Generate the payload to be signed for [JWS](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#supported-signature-envelopes) envelope format.
            1. Create the JWS protected headers collection and set `alg` to value corresponding to `describe-key.response.keySpec` as per [signature algorithm selection](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection).
            2. Create the `JWSPayload` with appropriate private (`subject`) and public (`iat,exp`) claims.
-           3. The payload to sign is then created as - `ASCII(BASE64URL(UTF8(ProtectedHeaders)) ‘.’ BASE64URL(JWSPayload))`
+           3. The *payload to sign* is then created as - `ASCII(BASE64URL(UTF8(ProtectedHeaders)) ‘.’ BASE64URL(JWSPayload))`
         3. Execute the plugin with `generate-signature` command.
            1. Set `request.keyId` and the optional `request.pluginConfig` to corresponding values associated with signing key `keyName` in `config.json`.
-           2. Set `request.payload` as the payload to sign.
+           2. Set `request.payload` as base64 encoded *payload to sign* (the JWS *payload to sign* is double encoded, this is a shortcoming of using plugin contract with JSON encoding).
            3. Set `keySpec` to value returned by `describe-key` command in `response.keySpec`, and `hashAlgorithm` to hash algorithm corresponding to the key spec, as per [signature algorithm selection](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection). The algorithm specified in `hashAlgorithm` MUST be used by the plugin to hash the payload (`request.payload`) as part of signature generation.
         4. Validate the generated signature, return an error if any of the checks fails.
            1. Check if `response.signingAlgorithm` is one of [supported signing algorithms](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection).
@@ -265,11 +265,8 @@ This command is used to generate the raw signature for a given payload.
   // hash the payload using this hash algorithm
   "hashAlgorithm" : "SHA_256" | "SHA_384" | "SHA_512",
 
-  // The signature envelope type associated with the payload.
-  "signatureEnvelopeType" : "application/vnd.cncf.notary.v2.jws.v1",
-  
-  // Payload to sign, it's encoded based on the signature envelope type
-  "payload" : "<payload to be signed>",
+  // Payload to sign, this is base64 encoded
+  "payload" : "<base64 encoded payload to be signed>",
 
 }
 ```
@@ -282,9 +279,7 @@ This command is used to generate the raw signature for a given payload.
 
 *hashAlgorithm* : Required field that specifies Hash algorithm corresponding to the signature algorithm determined by `keySpec` for the key.
 
-*signatureEnvelopeType* - Required field that specifies signature envelope type associated with the payload. This is used by the plugin to appropriately decode the payload in case a binary payload is passed.
-
-*payload* : Required field that contains payload to be signed. For JWS envelope type, the payload to sign is sent as is, without any additional encoding.
+*payload* : Required field that contains base64 encoded payload to be signed. For JWS, the *payload to sign* is base64 encoded (a second time) before sending to the plugin.
 
 *Response*
 

--- a/specs/plugin-extensibility.md
+++ b/specs/plugin-extensibility.md
@@ -32,13 +32,13 @@ Plugin publisher will provide instructions to download and install the plugin. P
 
 To enumerate all available plugins the following paths are scanned:
 * Unix-like OSes:
-  * `$HOME/.notation/plugins`
+  * `$HOME/notation/plugins`
 * On Windows:
-  * `%USERPROFILE%\.notation\plugins`
+  * `%USERPROFILE%\notation\plugins`
 
-Each plugin executable and dependencies are installed under directory `~/.notation/plugins/{plugin-name}` with an executable under that directory `~/.notation/plugins/{plugin-name}/notation-{plugin-name}`. 
+Each plugin executable and dependencies are installed under directory `~/notation/plugins/{plugin-name}` with an executable under that directory `~/notation/plugins/{plugin-name}/notation-{plugin-name}`.
 
-Any directory found inside `~/.notation/plugins` is considered potential plugin "candidates". Anything found which is not a directory is ignored and is not considered as a plugin candidate.
+Any directory found inside `~/notation/plugins` is considered potential plugin "candidates". Anything found which is not a directory is ignored and is not considered as a plugin candidate.
 
 To be considered a valid plugin a candidate must pass each of these "plugin candidate tests":
 
@@ -56,33 +56,49 @@ To be considered a valid plugin a candidate must pass each of these "plugin cand
 
 List all valid plugins.
 
-### Plugin configuration
+### Using a plugin for signing
 
 * To use a plugin for signing, the user associates the plugin as part of registering a signing key. E.g.
   * `notation key add --name "mysigningkey" --id "keyid" --plugin "com.example.nv2plugin"`
-  * In the example, the command registers a signing key in `/notation/config.json`, where `mysigningkey` is a friendly key name to refer during signing operation from the CLI, `id` is an key identifier known to plugin that is used for signing, and the value of `plugin` specifies it's using a plugin located at `~/.notation/plugins/com.example.nv2plugin/notation-com.example.nv2plugin`.
+  * In the example, the command registers a signing key in `/notation/config.json`, where `mysigningkey` is a friendly key name to refer during signing operation from the CLI, `id` is an key identifier known to plugin that is used for signing, and the value of `plugin` specifies it's using a plugin located at `~/notation/plugins/com.example.nv2plugin/notation-com.example.nv2plugin`.
   
 ```jsonc
 {
   "signingKeys": {  
     "default": "",  
     "keys": [
-      {  
-        "name": "mysigningkey",  
-        "id" : "keyid",
-        "plugin": "com.example.nv2plugin"
-      }  
+        {  
+          "name": "mysigningkey",  
+          "id" : "keyid",
+          "plugin": "com.example.nv2plugin",
+          // Optional configuration as required by the plugin
+          "pluginConfig" : {   
+            "key1" : "value1" 
+          }
+        }
     ]  
   }
 }
 ```
+
+### Plugin configuration
+
+Plugins may require additional configuration to work correctly, that could be set out of band, or provided by notation when it invokes a plugin. To support plugin configuration through notation, the key configuration provides an optional `pluginConfig` map of of key value pairs, that is passed as-is by notation to the plugin.
+
+* To use this feature, plugin authors MUST define and document the set of plugin configuration keys-values, which is set by users when they associate a plugin with signing key.
+* Plugin authors SHOULD NOT use plugin configuration to store sensitive configuration in plaintext, such as authentication keys used by the plugin etc.
+
+In the previous example, plugin config can be set using command line arguments as part of registring a key, or while signing using the key. Plugin config values provided by `notation sign` override values already set in `config.json` E.g.
+
+* `notation key add --name "mysigningkey" --id "keyid" --plugin "com.example.nv2plugin" --pluginConfig.key1 "value1"`
+* `notation sign $IMAGE --key "mysigningkey" --pluginConfig.key1 "value2"`
 
 ### Plugin contract
 
 * Notation will invoke the plugin executable for each command (e.g. sign, verify), pass inputs through `stdin` and get output through `stdout` and `stderr`.
 * The command will be passed as the first argument to the plugin e.g. `notary-{plugin-name} <command>`. A JSON request is passed using `stdin`. The plugin is expected to return a JSON response through `stdout` with a `0` exit code for successful response, and a non-zero exit code with a JSON error response in `stderr` for error response. Each command defines its request, response and error contract. To avoid any additional content like debug or info level logging from dependencies and inbuilt libraries, the plugin implementation should redirect any output to `stdout` on initialization, and only send the JSON response away from `stdout` when the command execution completes. E.g. For golang, set [`os.Stdout`](https://pkg.go.dev/os#pkg-variables) to point to a log file.
 * Every request JSON will contain a `contractVersion` top level attribute whose value will indicate the plugin contract version. Contract version is revised when there are changes to command request/response, new plugin commands are introduced, and supported through Notation.
-* For an error response, every command returns a non-zero exit code 1, with an OPTIONAL JSON error response in `stderr`. It is recommended to return an error response to help user troubleshoot the error.  There is no need to send different exit codes for different error conditions, as Notation (which will call the plugin and parse the response) will use `error-code` in the error response to interpret different error conditions if needed. Notation will attempt to parse the error response in `stderr` when exit code is 1, else treat it as a general error for any other non-zero exit codes. An implementation can 
+* For an error response, every command returns a non-zero exit code 1, with an OPTIONAL JSON error response in `stderr`. It is recommended to return an error response to help user troubleshoot the error.  There is no need to send different exit codes for different error conditions, as Notation (which will call the plugin and parse the response) will use `error-code` in the error response to interpret different error conditions if needed. Notation will attempt to parse the error response in `stderr` when exit code is 1, else treat it as a general error for any other non-zero exit codes.
 
 ```jsonc
 {
@@ -101,7 +117,7 @@ List all valid plugins.
 
 ### Plugin metadata
 
-* Every plugin MUST implement a metadata discovery command called `get-plugin-metadata`. 
+* Every plugin MUST implement a metadata discovery command called `get-plugin-metadata`.
 * Notation will invoke this command as part of signing and verification workflows to discover the capabilities of the plugin and subsequently invoke commands corresponding to the capabilities. Notation will invoke the `get-plugin-metadata` command every time a signing or verification workflow is invoked to discover metadata. Notation will not cache the response of `get-plugin-metadata` command as it involves invalidating cache when a plugin is updated, detecting a plugin update can be non trivial. The `get-plugin-metadata` command is expected to return only static data, and plugin implementors should avoid making remote calls in this command.
 
 ***get-plugin-metadata***
@@ -155,24 +171,30 @@ This interface targets plugins that integrate with providers of basic cryptograp
 
 #### Signing workflow using plugin
 
-1. Given a user request to sign `oci-artifact`, with `keyName` (the friendly key name)
-1. Pull the image manifest using `oci-artifact` url, and construct a descriptor
-1. Append any user provided metadata and Notary metadata as descriptor annotations.
-1. Determine if the registered key uses a plugin
-1. Execute the plugin with `get-plugin-metadata` command
+1. Given a user request to sign `oci-artifact`, with signing key `keyName` (the friendly key name)
+2. Pull the image manifest using `oci-artifact` url, and construct a descriptor
+3. Append any user provided metadata and Notary metadata as descriptor annotations.
+4. Determine if the registered key uses a plugin
+5. Execute the plugin with `get-plugin-metadata` command
     1. If plugin supports capability `SIGNATURE_GENERATOR`
-        1. Generate the payload to be signed. For JWS this includes [JWS](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#supported-signature-envelopes) payload with `subject` claim as descriptor, additional JWS claims, and protected headers.
-        2. Execute the plugin with `generate-signature` command, set `request.keyDefinition` to key definition corresponding to `keyName`, `request.payload` to the generated payload.
-        3. Validate the generated signature, return an error if any of the checks fails.
+        1. Execute the plugin with `describe-key` command, set `request.keyName`, `request.keyId` and the optional `request.pluginConfig` to corresponding values associated with signing key `keyName` in `config.json`.
+        2. Generate the payload to be signed for [JWS](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#supported-signature-envelopes) envelope format.
+           1. Create the protected headers collection and set `alg` to value corresponding to `describe-key.response.keySpec` as per [signature algorithm selection](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection).
+           2. Create the `JWSPayload` with appropriate private (`subject`) and public (`iat,exp`) claims.
+           3. The payload to sign is then created as - `ASCII(BASE64URL(UTF8(ProtectedHeaders)) ‘.’ BASE64URL(JWSPayload))`
+        3. Execute the plugin with `generate-signature` command. Set `request.keyName`, `request.keyId` and the optional `request.pluginConfig` to corresponding values associated with signing key `keyName` in `config.json`. Set `request.payload` as the payload to sign.
+        4. Validate the generated signature, return an error if any of the checks fails.
            1. Check if `response.signingAlgorithm` is one of [supported signing algorithms](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection).
-           2. Check that the plugin did not modify `request.payload` before generating the signature, and the signature is valid for the given payload. Verify the hash of the `request.payload` against `response.signature`, using the public key of signing certificate (leaf certificate) in `response.certificateChain` along with the `response.signingAlgorithm`. This step does not include certificate chain validation (certificate chain leads to a trusted root configured in Notation), or revocation check.
+           2. Check that the plugin did not modify `request.payload` before generating the signature, and the signature is valid for the given payload. Verify the hash of the `request.payload` against `response.signature`, using the public key of signing certificate (leaf certificate) in `response.certificateChain` along with the `response.signingAlgorithm`. This step does not include certificate chain validation (certificate chain leads to a trusted root configured in Notation's Trust Store), or revocation check.
            3. Check that the `response.certificateChain` conforms to [Certificate Requirements](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#certificate-requirements).
-        4. Assemble the JWS Signature envelope using `response.signature`, `response.signingAlgorithm` and `response.certificateChain`. Notation may also generate and include timestamp signature in this step.
-        5. Generate a signature manifest for the given signature envelope.
-    2. Else if plugin supports capability `SIGNATURE_ENVELOPE_GENERATOR` *(covered in next section)*
+        5. Assemble the JWS Signature envelope using `response.signature`, `response.signingAlgorithm` and `response.certificateChain`. Notation may also generate and include timestamp signature in this step.
+        6. Generate a signature manifest for the given signature envelope.
+    2. Else if, plugin supports capability `SIGNATURE_ENVELOPE_GENERATOR` *(covered in next section)*
     3. Return an error
 
-***generate-signature***
+#### describe-key
+
+This command is used to get metadata for a given key.
 
 *Request*
 
@@ -180,28 +202,74 @@ This interface targets plugins that integrate with providers of basic cryptograp
 {
   "contractVersion" : "<major-version.minor-version>",
 
-  // Complete key definition from
-  // /notation/config.json /signingKeys/keys with matching key name
-  "keyDefinition" : "<key definition>",
+  // Key name, key id for the key associated with the plugin
+  // in config.json /signingKeys/keys
+  "keyName": "<key name>",
+  "keyId": "<key id>",
 
-  "payload" : "<Base64 encoded payload to be signed>"
+  // Optional plugin configuration, map of string-string
+  "pluginConfig" : { }
 }
 ```
 
-*keyDefinition* : Required field that contains the complete key definition, which includes friendly name (`name`), key identifier (`id`) and any additional custom fields required by the plugin.
-For example, after registering a key `mysigningkey` and plugin, the command `notation sign $IMAGE --key "mysigningkey"` will subsequently invoke plugin with `request.keyDefinition` set to following value.
+*keyName* and *keyId* : Required fields that contain the friendly signing key name (`keyName`) and key identifier (`keyId`) as specified in `config.json`.
 
-```jsonc
-{  
-  "name": "mysigningkey",  
-  "id" : "keyid",
-  "plugin": "com.example.nv2plugin"
-}
-```
-
-*payload* : Required field that contains payload to be signed. This is currently the JWSPayload that includes the subject descriptor and other JWS claims.
+*pluginConfig* : Optional field for plugin configuration. For details, see [Plugin Configuration](#plugin-configuration) section.
 
 *Response*
+
+```jsonc
+{
+   // The same key id as passed in the request.
+  "keyId" : "<key id>",
+  "keySpec" : "<key type and size>"
+}
+```
+
+*keySpec* : One of following [supported key types](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection) - `RSA_2048`, `RSA_3072`, `RSA_4096`, `EC_256`, `EC_384`, `EC_512`.
+
+NOTE: This command can also be used as part of `notation key describe {key-name}` which will include the following output
+
+* Summary of key definition from `config.json`
+* If the key has an associated plugin
+  * Output of plugin `discover` command
+  * Output of `describe-key` command for the specific key
+
+#### generate-signature
+
+This command is used to generate the raw signature for a given payload.
+
+*Request*
+
+```jsonc
+{
+  "contractVersion" : "<major-version.minor-version>",
+
+  // Key name, key id for the key associated with the plugin
+  // in config.json /signingKeys/keys
+  "keyName": "<key name>",
+  "keyId": "<key id>",
+
+  // Optional plugin configuration, map of string-string
+  "pluginConfig" : { },
+
+  // The signature envelope type associated with the payload.
+  "signatureEnvelopeType" : "application/vnd.cncf.notary.v2.jws.v1",
+  
+  "payload" : "<payload to be signed>"
+}
+```
+
+*keyName* and *keyId* : Required fields that contain the friendly key name (`keyName`), key identifier (`keyId`) as specified in `config.json`.
+
+*pluginConfig* : Optional field for plugin configuration. For details, see [Plugin Configuration section](#plugin-configuration).
+
+*signatureEnvelopeType* - The signature envelope type associated with the payload. This is used by the plugin to appropriately decode the payload in case a binary payload is passed.
+
+*payload* : Required field that contains payload to be signed. For JWS envelope type, the payload to sign is sent as is, without any additional encoding.
+
+*Response*
+
 All response attributes are required.
 
 ```jsonc
@@ -218,7 +286,7 @@ All response attributes are required.
 
 *certificateChain* : Ordered list of certificates starting with leaf certificate and ending with root certificate.
 
-*Error codes*
+#### Error codes for describe-key and generate-signature
 
 * VALIDATION_ERROR - Any of the required request fields was empty, or a value was malformed/invalid. Includes condition where the key referenced by `keyId` was not found.
 * UNSUPPORTED_CONTRACT_VERSION - The contract version used in the request is unsupported.
@@ -239,8 +307,8 @@ This interface targets plugins that in addition to signature generation want to 
 1. Determine if the registered key uses a plugin
 1. Execute the plugin with `get-plugin-metadata` command
     1. If plugin supports capability `SIGNATURE_ENVELOPE_GENERATOR`
-        1. Execute the plugin with `generate-envelope` command, set `request.keyDefinition` to key definition (from `/notation/config.json`) corresponding to `keyName`, `request.payload` to base64 encoded descriptor, `request.payloadType` to `application/vnd.oci.descriptor.v1+json` and `request.signatureEnvelopeType` to a pre-defined type (default to `application/vnd.cncf.notary.v2.jws.v1`).
-        1. `response.signatureEnvelope` contains the base64 encoded signature envelope, value of `response.signatureEnvelopeType` MUST match request.signatureEnvelopeType.
+        1. Execute the plugin with `generate-envelope` command. Set `request.keyName`, `request.keyId` and the optional `request.pluginConfig` to corresponding values associated with signing key `keyName` in `config.json`. Set `request.payload` to base64 encoded descriptor, `request.payloadType` to `application/vnd.oci.descriptor.v1+json` and `request.signatureEnvelopeType` to a pre-defined type (default to `application/vnd.cncf.notary.v2.jws.v1`).
+        1. `response.signatureEnvelope` contains the base64 encoded signature envelope, value of `response.signatureEnvelopeType` MUST match `request.signatureEnvelopeType`.
         1. Validate the generated signature, return an error if of the checks fails.
            1. Check if `response.signatureEnvelopeType` is a supported envelope type and `response.signatureEnvelope`'s format matches `response.signatureEnvelopeType`. 
            1. Check if the signing algorithm in the signature envelope is one of [supported signing algorithms](https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection).
@@ -251,7 +319,9 @@ This interface targets plugins that in addition to signature generation want to 
     1. Else if plugin supports capability `SIGNATURE_GENERATOR` *(covered in previous section)*
     1. Return an error
 
-**generate-envelope**
+#### generate-envelope
+
+This command is used to generate the complete signature envelope for a given payload.
 
 *Request*
 All request attributes are required.
@@ -260,8 +330,13 @@ All request attributes are required.
 {
   "contractVersion" : "<major-version.minor-version>",
   
-  // Complete key definition from /notation/config.JSON /signingKeys/keys with matching key name
-  "keyDefinition" : "<key definition>", 
+  // Key name, key id for the key associated with the plugin
+  // in config.json /signingKeys/keys
+  "keyName": "<key name>",
+  "keyId": "<key id>",
+
+  // Optional plugin configuration, map of string-string
+  "pluginConfig" : { },
 
   "payload" : "<Base64 encoded payload to be signed>",
   
@@ -273,12 +348,15 @@ All request attributes are required.
 }
 ```
 
+*keyName* and *keyId* : Required fields that contain the friendly key name (`keyName`), key identifier (`keyId`) as specified in `config.json`.
+
+*pluginConfig* : Optional field for plugin configuration. For details, see [Plugin Configuration section](#plugin-configuration).
+
 *signatureEnvelopeType* - defines the type of signature envelope expected from the plugin. As  Notation clients need to be updated in order to parse and verify new signature formats, the default signature format can only be changed with new major version releases of Notation. Users however can opt into using an updated signature format supported by Notation, by passing an optional parameter.
 e.g. `notation sign $IMAGE --key {key-name} --signatureFormat {some-new-format}`
 
 *Response*
 All response attributes are required.
-
 
 ```jsonc
 {
@@ -293,7 +371,7 @@ All response attributes are required.
 }
 ```
 
-*Error codes*
+#### Error codes for generate-envelope
 
 * VALIDATION_ERROR - Any of the required request fields was empty, or a value was malformed/invalid. Includes condition where the key referenced by `keyId` was not found, payload type or signature envelope type in the request is unsupported by the plugin.
 * UNSUPPORTED_CONTRACT_VERSION - The contract version used in the request is unsupported.
@@ -310,9 +388,14 @@ TBD [notaryproject/roadmap#27](https://github.com/notaryproject/roadmap/issues/2
 
 TBD [#135](https://github.com/notaryproject/notaryproject/issues/135)
 
+## FAQ
+
+**Q: Will Notation generate timestamp signature for Signature Envelope Generator plugin or its responsibility of plugin publisher?**
+
+**A :** If the envelope generated by a Signature Envelope Generator plugin contains timestamp signature, Notation will not append additional timestamp signature, else it will generate the timestamp signature and append it to the envelope as an unsigned attribute.
+
 ## Open Items
-* Will Notation generate timestamp signature for Signature Envelope Generator plugin or its responsibility of plugin publisher?
+
 * [Issue #151](https://github.com/notaryproject/notation/issues/151) - Add Notation command line options to pass raw signature generated by existing crypto tools.
 * What standard providers should be supported?
-* Do we need to support file based plugin configuration, or pass-through plugin configuration passed as is from Notation CLI to the plugin?
 * Support for chaining plugins. It allows us to separate out and compose things like signing, TSA integration, push to transparency log.


### PR DESCRIPTION
* Changed plugin path from `~/.notation/plugins/` to `~/notation/plugins/` to be consistent with other paths that use $XDG_CONFIG_HOME
* Updated `Signature Generator` workflow to include `describe-key` command, which is required to find the signing algorithm (to set `alg` header) before payload to sign is generated.
* Added spec for pass-through plugin config using CLI and `config.json`
* Minor formatting updates

cc: @qmuntal , @rgnote, @shizhMSFT  for review

Signed-off-by: Milind Gokarn <gokarnm@amazon.com>