### PR TITLE
Relax EKU requirements on signing certificates

### DIFF
--- a/signature-specification.md
+++ b/signature-specification.md
@@ -214,7 +214,7 @@ The `basicConstraints` extension is OPTIONAL and can OPTIONALLY be marked as cri
 1. **[Key Usage:](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3)**
 The `keyUsage` extension MUST be present and MUST be marked critical. Bit positions for `digitalSignature` MUST be set. The Bit positions for `keyCertSign` and `cRLSign` MUST NOT be set.
 1. **[Extended Key Usage:](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12)**  The `extendedKeyUsage` extension is OPTIONAL and can OPTIONALLY be marked as critical.
-    - **For codesigning certificate:** If present, the value MUST contain `id-kp-codeSigning` and MUST NOT contain `anyExtendedKeyUsage`, `serverAuth`, `emailProtection` and `timeStamping`.
+    - **For signing certificate:** If present, the value MAY contain `id-kp-codeSigning` and MUST NOT contain `anyExtendedKeyUsage`, `serverAuth`, `emailProtection` and `timeStamping`.
     - **For timestamping certificate:** If present, the value MUST contain `id-kp-timeStamping` and MUST NOT contain `anyExtendedKeyUsage`, `serverAuth`, `emailProtection` and `codeSigning`.
 1. **Key Length** The certificate MUST abide by the following key length restrictions:
     - For RSA public key, the key length MUST be 2048 bits or higher.


### PR DESCRIPTION
Softening the requirement on the "signing" certificate (not "codesigning") for the signing of content in the registry to "MAY" contain the codeSign EKU ('id-kp-codeSigning') is the best way to allow for a wider variety of existing certificates and new EKUs to be defined for the signing of content types that are not "software" as defined in RFC 4949. Using code signing certificates (with the codeSign EKU) for signing data objects that are not software or directly related to the execution of software can lead to unintended trust by existing code integrity implementations that rightly require the codeSign EKU. As such, Private PKI owners may want to NOT issue code signing certificates to entities that are signing content in the registry that is not code (e.g. Container descriptors), not requiring the codeSigning EKU allows them to create the right controls on entities allowed to use codesigning certificates vs. entities that should/must not use codesigning certificates.