### PR TITLE
feat(plugin)!: pass payload digest when `generate-signature`

### DIFF
--- a/specs/plugin-extensibility.md
+++ b/specs/plugin-extensibility.md
@@ -250,7 +250,7 @@ This command is used to get metadata for a given key.
 }
 ```
 
-*keySpec* : One of following [supported key types](../signature-specification.md#algorithm-selection) - `RSA_2048`, `RSA_3072`, `RSA_4096`, `EC_256`, `EC_384`, `EC_512`.
+*keySpec* : One of following [supported key types](../signature-specification.md#algorithm-selection) - `RSA-2048`, `RSA-3072`, `RSA-4096`, `EC-256`, `EC-384`, `EC-521`.
 
 *certificateChain* : Ordered list of certificates starting with leaf certificate and ending with root certificate.
 
@@ -283,7 +283,7 @@ This command is used to generate the raw signature for a given payload.
 
   // Hash algorithm associated with the key spec, plugin must 
   // hash the payload using this hash algorithm
-  "hashAlgorithm": "SHA_256" | "SHA_384" | "SHA_512",
+  "hashAlgorithm": "SHA-256" | "SHA-384" | "SHA-512",
 
   // Digest of payload to sign, this is base64 encoded
   "payloadDigest": "<base64 encoded digest of payload to be signed>"
@@ -294,7 +294,7 @@ This command is used to generate the raw signature for a given payload.
 
 *pluginConfig* : Optional field for plugin configuration. For details, see [Plugin Configuration section](#plugin-configuration).
 
-*keySpec* : Required field that has one of following [supported key types](../signature-specification.md#algorithm-selection) - `RSA_2048`, `RSA_3072`, `RSA_4096`, `EC_256`, `EC_384`, `EC_512`. Specifies the key type and size for the key.
+*keySpec* : Required field that has one of following [supported key types](../signature-specification.md#algorithm-selection) - `RSA-2048`, `RSA-3072`, `RSA-4096`, `EC-256`, `EC-384`, `EC-521`. Specifies the key type and size for the key.
 
 *hashAlgorithm* : Required field that specifies Hash algorithm corresponding to the signature algorithm determined by `keySpec` for the key.
 
@@ -313,7 +313,14 @@ All response attributes are required.
 }
 ```
 
-*signingAlgorithm* : One of following [supported signing algorithms](../signature-specification.md#algorithm-selection), Notation uses this validate the signature, and to set the appropriate attribute in signature envelope (e.g. JWS `alg`). `RSASSA_PSS_SHA_256`, `RSASSA_PSS_SHA_384`, `RSASSA_PSS_SHA_512`,  `ECDSA_SHA_256`, `ECDSA_SHA_384`, `ECDSA_SHA_512`.
+*signingAlgorithm* : One of following [supported signing algorithms](../signature-specification.md#algorithm-selection), Notation uses this validate the signature, and to set the appropriate attribute in signature envelope (e.g. JWS `alg`). Supported values are
+
+* `PS256`: RSASSA-PSS with SHA-256
+* `PS384`: RSASSA-PSS with SHA-384
+* `PS512`: RSASSA-PSS with SHA-512
+* `ES256`: ECDSA on secp256r1 with SHA-256
+* `ES384`: ECDSA on secp384r1 with SHA-384
+* `ES512`: ECDSA on secp521r1 with SHA-512
 
 #### Error codes for describe-key and generate-signature
 

--- a/specs/plugin-extensibility.md
+++ b/specs/plugin-extensibility.md
@@ -285,8 +285,8 @@ This command is used to generate the raw signature for a given payload.
   // hash the payload using this hash algorithm
   "hashAlgorithm": "SHA_256" | "SHA_384" | "SHA_512",
 
-  // Payload to sign, this is base64 encoded
-  "payload": "<base64 encoded payload to be signed>"
+  // Digest of payload to sign, this is base64 encoded
+  "payloadDigest": "<base64 encoded digest of payload to be signed>"
 }
 ```
 
@@ -298,7 +298,7 @@ This command is used to generate the raw signature for a given payload.
 
 *hashAlgorithm* : Required field that specifies Hash algorithm corresponding to the signature algorithm determined by `keySpec` for the key.
 
-*payload* : Required field that contains base64 encoded payload to be signed. For JWS, the *payload to sign* is base64 encoded (a second time) before sending to the plugin.
+*payloadDigest* : Required field that contains base64 encoded digest of payload to be signed.
 
 *Response*
 

--- a/specs/plugin-extensibility.md
+++ b/specs/plugin-extensibility.md
@@ -286,7 +286,7 @@ This command is used to generate the raw signature for a given payload.
   // hash the payload using this hash algorithm
   "hashAlgorithm": "SHA-256" | "SHA-384" | "SHA-512",
 
-  // Digest of payload to sign, this is base64 encoded
+  // Payload digest to sign, this is base64 encoded
   "payloadDigest": "<base64 encoded digest of payload to be signed>"
 }
 ```

--- a/specs/plugin-extensibility.md
+++ b/specs/plugin-extensibility.md
@@ -199,7 +199,6 @@ This interface targets plugins that integrate with providers of basic cryptograp
 5. Execute the plugin with `get-plugin-metadata` command
     1. If plugin supports capability `SIGNATURE_GENERATOR.RAW`
         1. Execute the plugin with `describe-key` command, set `request.keyId` and the optional `request.pluginConfig` to corresponding values associated with signing key `keyName` in `config.json`.
-            1. Check that the `response.certificateChain` conforms to [Certificate Requirements](../signature-specification.md#certificate-requirements).
         2. Generate the payload digest to be signed for [JWS](../signature-specification.md#supported-signature-envelopes) envelope format.
             1. Create the JWS protected headers collection and set `alg` to value corresponding to `describe-key.response.keySpec` as per [signature algorithm selection](../signature-specification.md#algorithm-selection).
             2. Determine the *payload hash algorithm* corresponding to `describe-key.response.keySpec` as per [signature algorithm selection](../signature-specification.md#algorithm-selection).
@@ -211,8 +210,9 @@ This interface targets plugins that integrate with providers of basic cryptograp
             3. Set `request.keySpec` to `describe-key.response.keySpec`, and `request.hashAlgorithm` to *payload hash algorithm*.
         4. Validate the generated signature, return an error if any of the checks fails.
             1. Check if `response.signingAlgorithm` is one of [supported signing algorithms](../signature-specification.md#algorithm-selection).
-            2. Verify the `request.payloadDigest` against `response.signature`, using the public key of signing certificate (leaf certificate) in `describe-key.response.certificateChain` along with the `response.signingAlgorithm`. This step does not include certificate chain validation (certificate chain leads to a trusted root configured in Notation's Trust Store), or revocation check.
-        5. Assemble the JWS Signature envelope using `response.signature`, `response.signingAlgorithm` and `describe-key.response.certificateChain`. Notation may also generate and include timestamp signature in this step.
+            2. Verify the `request.payloadDigest` against `response.signature`, using the public key of signing certificate (leaf certificate) in `response.certificateChain` along with the `response.signingAlgorithm`. This step does not include certificate chain validation (certificate chain leads to a trusted root configured in Notation's Trust Store), or revocation check.
+            3. Check that the `response.certificateChain` conforms to [Certificate Requirements](../signature-specification.md#certificate-requirements).
+        5. Assemble the JWS Signature envelope using `response.signature`, `response.signingAlgorithm` and `response.certificateChain`. Notation may also generate and include timestamp signature in this step.
         6. Generate a signature manifest for the given signature envelope.
     2. Else if, plugin supports capability `SIGNATURE_GENERATOR.ENVELOPE` *(covered in next section)*
     3. Return an error
@@ -244,16 +244,13 @@ This command is used to get metadata for a given key.
 
 ```jsonc
 {
-  // The same key id as passed in the request.
-  "keyId": "<key id>",
-  "keySpec": "<key type and size>",
-  "certificateChain": ["Base64(DER(leafCert))","Base64(DER(intermediateCACert))","Base64(DER(rootCert))"]
+   // The same key id as passed in the request.
+  "keyId" : "<key id>",
+  "keySpec" : "<key type and size>"
 }
 ```
 
 *keySpec* : One of following [supported key types](../signature-specification.md#algorithm-selection) - `RSA_2048`, `RSA_3072`, `RSA_4096`, `EC_256`, `EC_384`, `EC_512`.
-
-*certificateChain* : Ordered list of certificates starting with leaf certificate and ending with root certificate.
 
 NOTE: This command can also be used as part of `notation key describe {key-name}` which will include the following output
 
@@ -308,13 +305,16 @@ All response attributes are required.
 ```jsonc
 {    
   // The same key id as passed in the request.
-  "keyId": "<key id>",
-  "signature": "<Base64 encoded signature>",
-  "signingAlgorithm": "<signing algorithm>"
+  "keyId" : "<key id>",
+  "signature" : "<Base64 encoded signature>",
+  "signingAlgorithm" : "<signing algorithm>",
+  "certificateChain": ["Base64(DER(leafCert))","Base64(DER(intermediateCACert))","Base64(DER(rootCert))"]
 }
 ```
 
 *signingAlgorithm* : One of following [supported signing algorithms](../signature-specification.md#algorithm-selection), Notation uses this validate the signature, and to set the appropriate attribute in signature envelope (e.g. JWS `alg`). `RSASSA_PSS_SHA_256`, `RSASSA_PSS_SHA_384`, `RSASSA_PSS_SHA_512`,  `ECDSA_SHA_256`, `ECDSA_SHA_384`, `ECDSA_SHA_512`.
+
+*certificateChain* : Ordered list of certificates starting with leaf certificate and ending with root certificate.
 
 #### Error codes for describe-key and generate-signature
 

--- a/specs/plugin-extensibility.md
+++ b/specs/plugin-extensibility.md
@@ -243,13 +243,16 @@ This command is used to get metadata for a given key.
 
 ```jsonc
 {
-   // The same key id as passed in the request.
-  "keyId" : "<key id>",
-  "keySpec" : "<key type and size>"
+  // The same key id as passed in the request.
+  "keyId": "<key id>",
+  "keySpec": "<key type and size>",
+  "certificateChain": ["Base64(DER(leafCert))","Base64(DER(intermediateCACert))","Base64(DER(rootCert))"]
 }
 ```
 
 *keySpec* : One of following [supported key types](../signature-specification.md#algorithm-selection) - `RSA_2048`, `RSA_3072`, `RSA_4096`, `EC_256`, `EC_384`, `EC_512`.
+
+*certificateChain* : Ordered list of certificates starting with leaf certificate and ending with root certificate.
 
 NOTE: This command can also be used as part of `notation key describe {key-name}` which will include the following output
 
@@ -273,18 +276,17 @@ This command is used to generate the raw signature for a given payload.
   "keyId": "<key id>",
 
   // Optional plugin configuration, map of string-string
-  "pluginConfig" : { },
+  "pluginConfig": { },
 
   // The key spec for the given key id
-  "keySpec" : "<key type and size>",
+  "keySpec": "<key type and size>",
 
   // Hash algorithm associated with the key spec, plugin must 
   // hash the payload using this hash algorithm
-  "hashAlgorithm" : "SHA_256" | "SHA_384" | "SHA_512",
+  "hashAlgorithm": "SHA_256" | "SHA_384" | "SHA_512",
 
   // Payload to sign, this is base64 encoded
-  "payload" : "<base64 encoded payload to be signed>",
-
+  "payload": "<base64 encoded payload to be signed>"
 }
 ```
 
@@ -305,16 +307,13 @@ All response attributes are required.
 ```jsonc
 {    
   // The same key id as passed in the request.
-  "keyId" : "<key id>",
-  "signature" : "<Base64 encoded signature>",
-  "signingAlgorithm" : "<signing algorithm>",
-  "certificateChain": ["Base64(DER(leafCert))","Base64(DER(intermediateCACert))","Base64(DER(rootCert))"]
+  "keyId": "<key id>",
+  "signature": "<Base64 encoded signature>",
+  "signingAlgorithm": "<signing algorithm>"
 }
 ```
 
 *signingAlgorithm* : One of following [supported signing algorithms](../signature-specification.md#algorithm-selection), Notation uses this validate the signature, and to set the appropriate attribute in signature envelope (e.g. JWS `alg`). `RSASSA_PSS_SHA_256`, `RSASSA_PSS_SHA_384`, `RSASSA_PSS_SHA_512`,  `ECDSA_SHA_256`, `ECDSA_SHA_384`, `ECDSA_SHA_512`.
-
-*certificateChain* : Ordered list of certificates starting with leaf certificate and ending with root certificate.
 
 #### Error codes for describe-key and generate-signature
 

--- a/specs/plugin-extensibility.md
+++ b/specs/plugin-extensibility.md
@@ -251,7 +251,7 @@ This command is used to get metadata for a given key.
 }
 ```
 
-*keySpec* : One of following [supported key types](../signature-specification.md#algorithm-selection) - `RSA-2048`, `RSA-3072`, `RSA-4096`, `EC-256`, `EC-384`, `EC-521`.
+*keySpec* : One of following [supported key types](../signature-specification.md#algorithm-selection) - `RSA_2048`, `RSA_3072`, `RSA_4096`, `EC_256`, `EC_384`, `EC_512`.
 
 *certificateChain* : Ordered list of certificates starting with leaf certificate and ending with root certificate.
 
@@ -284,7 +284,7 @@ This command is used to generate the raw signature for a given payload.
 
   // Hash algorithm associated with the key spec, plugin must 
   // hash the payload using this hash algorithm
-  "hashAlgorithm": "SHA-256" | "SHA-384" | "SHA-512",
+  "hashAlgorithm": "SHA_256" | "SHA_384" | "SHA_512",
 
   // Payload digest to sign, this is base64 encoded
   "payloadDigest": "<base64 encoded digest of payload to be signed>"
@@ -295,7 +295,7 @@ This command is used to generate the raw signature for a given payload.
 
 *pluginConfig* : Optional field for plugin configuration. For details, see [Plugin Configuration section](#plugin-configuration).
 
-*keySpec* : Required field that has one of following [supported key types](../signature-specification.md#algorithm-selection) - `RSA-2048`, `RSA-3072`, `RSA-4096`, `EC-256`, `EC-384`, `EC-521`. Specifies the key type and size for the key.
+*keySpec* : Required field that has one of following [supported key types](../signature-specification.md#algorithm-selection) - `RSA_2048`, `RSA_3072`, `RSA_4096`, `EC_256`, `EC_384`, `EC_512`. Specifies the key type and size for the key.
 
 *hashAlgorithm* : Required field that specifies Hash algorithm corresponding to the signature algorithm determined by `keySpec` for the key.
 
@@ -314,14 +314,7 @@ All response attributes are required.
 }
 ```
 
-*signingAlgorithm* : One of following [supported signing algorithms](../signature-specification.md#algorithm-selection), Notation uses this validate the signature, and to set the appropriate attribute in signature envelope (e.g. JWS `alg`). Supported values are
-
-* `PS256`: RSASSA-PSS with SHA-256
-* `PS384`: RSASSA-PSS with SHA-384
-* `PS512`: RSASSA-PSS with SHA-512
-* `ES256`: ECDSA on secp256r1 with SHA-256
-* `ES384`: ECDSA on secp384r1 with SHA-384
-* `ES512`: ECDSA on secp521r1 with SHA-512
+*signingAlgorithm* : One of following [supported signing algorithms](../signature-specification.md#algorithm-selection), Notation uses this validate the signature, and to set the appropriate attribute in signature envelope (e.g. JWS `alg`). `RSASSA_PSS_SHA_256`, `RSASSA_PSS_SHA_384`, `RSASSA_PSS_SHA_512`,  `ECDSA_SHA_256`, `ECDSA_SHA_384`, `ECDSA_SHA_512`.
 
 #### Error codes for describe-key and generate-signature
 


### PR DESCRIPTION
Changes to `SIGNATURE_GENERATOR.RAW` capability:

* `payloadDigest` instead of `payload` is passed in `generate-signature.request`.
  * Since only the digest of the payload is required, the plugin can fit [crypto.Signer](https://pkg.go.dev/crypto#Signer), and it simplifies the implementation of `notation-core-go`.
  * For the concern of the FIPS-compliance of hash implementation, it is not sufficient to delegate the hash computation to the plugin as `notation-go` still uses golang built-in hash implementation to do signature and certificate validation. For advanced scenarios, it should be considered compiling `notation` under FIPS-compliant golang or implementing a plugin with `SIGNATURE_GENERATOR.ENVELOPE` capability.

Signed-off-by: Shiwei Zhang <shizh@microsoft.com>