### PR TITLE
doc: notation supports OCI Image manifest

### DIFF
--- a/specs/signature-specification.md
+++ b/specs/signature-specification.md
@@ -90,8 +90,8 @@ Besides the [image manifest property requirements][image-manifest-property-descr
 - **`mediaType`** (*string*): This REQUIRED property MUST be `application/vnd.oci.image.manifest.v1+json`.
 - **`config`** (*descriptor*): This property is REQUIRED to be compatible with [OCI image specification][oci-image-manifest]. Notary v2 doesn't require any configurations for a signature, and the configuration contents are not consumed by Notary v2.
   - **`mediaType`** (*string*): This REQUIRED property MUST be `application/vnd.cncf.notary.signature`.
-  - **`digest`** (*string*): This REQUIRED property is the digest of the targeted content.
-  - **`size`** (*int64*): This REQUIRED property specifies the size, in bytes, of the raw content.
+  - **`digest`** (*string*): This REQUIRED property is the digest of the config content.
+  - **`size`** (*int64*): This REQUIRED property specifies the size, in bytes, of the raw config content.
 - **`layers`** (*array of objects*): This REQUIRED property contains collection of only one [OCI descriptor][oci-descriptor] referencing signature envelope.
   - **`mediaType`** (*string*): This REQUIRED property contains media type of signature envelope blob. Following values are supported
     - `application/jose+json`

--- a/specs/signature-specification.md
+++ b/specs/signature-specification.md
@@ -14,7 +14,7 @@ The signature manifest has an artifact type that specifies it's a Notary V2 sign
 
 ![Signature storage inside registry](../media/signature-specification.svg)
 
-Signature Manifest Example per OCI artifact manifest
+Signature manifest example per OCI artifact manifest
 
 ```jsonc
 {
@@ -55,14 +55,14 @@ Signature Manifest Example per OCI artifact manifest
 
 Notary v2 MAY support using [OCI Image manifest][oci-image-manifest] to store the signature in the registries that implement partial or older versions of the OCI Image specification.
 
-Signature Manifest example per OCI Image manifest:
+Signature manifest example per OCI image manifest:
 
 ```jsonc
 {
     "schemaVersion": 2,
     "mediaType": "application/vnd.oci.image.manifest.v1+json",
     "config": {
-        "mediaType": "application/vnd.oci.image.config.v1+json",
+        "mediaType": "application/vnd.cncf.notary.signature",
         "size": 2,
         "digest": "sha256:ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356"
     },
@@ -88,7 +88,10 @@ Signature Manifest example per OCI Image manifest:
 Besides the [image manifest property requirements][image-manifest-property-descriptions], the properties has the following additional restrictions:
 
 - **`mediaType`** (*string*): This REQUIRED property MUST be `application/vnd.oci.image.manifest.v1+json`.
-- **`config`** (*descriptor*): This REQUIRED property references a configuration object for a signature by digest.
+- **`config`** (*descriptor*): This REQUIRED property references a configuration object for a signature by digest. Notary v2 doesn't require specific configurations for a signature. Implementations SHOULD decide the configuration content based on their specific needs.
+  - **`mediaType`** (*string*): This REQUIRED property MUST be `application/vnd.cncf.notary.signature`.
+  - **`digest`** (*string*): This REQUIRED property is the digest of the targeted content.
+  - **`size`** (*int64*): This REQUIRED property specifies the size, in bytes, of the raw content.
 - **`layers`** (*array of objects*): This REQUIRED property contains collection of only one [OCI descriptor][oci-descriptor] referencing signature envelope.
   - **`mediaType`** (*string*): This REQUIRED property contains media type of signature envelope blob. Following values are supported
     - `application/jose+json`
@@ -357,7 +360,7 @@ Alternatively, an implementation of Notary v2 can choose not to implement plugin
 [annotation-rules]: https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules
 [oci-descriptor]: https://github.com/opencontainers/image-spec/blob/main/descriptor.md
 [ietf-rfc3161]: https://datatracker.ietf.org/doc/html/rfc3161#section-2.4.2
-[oci-artifact-manifest]: https://github.com/opencontainers/image-spec/blob/main/artifact.md
-[oci-distribution-referrers]: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
-[oci-image-manifest]: https://github.com/opencontainers/image-spec/blob/main/manifest.md
-[image-manifest-property-descriptions]: https://github.com/opencontainers/image-spec/blob/main/manifest.md#image-manifest-property-descriptions
+[oci-artifact-manifest]: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/artifact.md
+[oci-distribution-referrers]: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers
+[oci-image-manifest]: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md
+[image-manifest-property-descriptions]: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md#image-manifest-property-descriptions

--- a/specs/signature-specification.md
+++ b/specs/signature-specification.md
@@ -8,7 +8,7 @@ This document provides the following details for Notary v2 signatures:
 ## Storage
 
 This section describes how Notary v2 signatures are stored in the OCI Distribution conformant registry.
-Notary v2 uses [OCI artifact manifest][oci-artifact-manifest] to store the signature in the registry.
+Notary v2 uses [OCI artifact manifest][oci-artifact-manifest] to store signatures in the registry.
 The media type of the signature manifest is `application/vnd.oci.artifact.manifest.v1+json`.
 The signature manifest has an artifact type that specifies it's a Notary V2 signature, a reference to the manifest of the artifact being signed, a blob referencing the signature, and a collection of annotations.
 
@@ -53,7 +53,7 @@ Signature manifest example per OCI artifact manifest
 
 ### Backward Compatibility
 
-Notary v2 MAY support using `OCI image manifest` to store the signature in the registries that implement partial of the [OCI image specification v1.1][oci-image-manifest].
+Notary v2 MAY support using `OCI image manifest` to store signatures in the registries that implement partial of the [OCI image specification v1.1][oci-image-manifest].
 
 Signature manifest example per OCI image manifest:
 
@@ -85,14 +85,14 @@ Signature manifest example per OCI image manifest:
 }
 ```
 
-Besides the [image manifest property requirements][image-manifest-property-descriptions], the properties has the following additional restrictions:
+Besides the [image manifest property requirements][image-manifest-property-descriptions], the properties have the following additional restrictions:
 
 - **`mediaType`** (*string*): This REQUIRED property MUST be `application/vnd.oci.image.manifest.v1+json`.
-- **`config`** (*descriptor*): This property is REQUIRED to be compatible with [OCI image specification][oci-image-manifest]. Notary v2 doesn't require any configurations for a signature, and the configuration contents are not consumed by Notary v2.
+- **`config`** (*descriptor*): This property is REQUIRED to be compatible with [OCI image specification][oci-image-manifest]. Notary v2 doesn't require any configuration for a signature, and the configuration content is not consumed by Notary v2.
   - **`mediaType`** (*string*): This REQUIRED property MUST be `application/vnd.cncf.notary.signature`.
   - **`digest`** (*string*): This REQUIRED property is the digest of the config content.
   - **`size`** (*int64*): This REQUIRED property specifies the size, in bytes, of the raw config content.
-- **`layers`** (*array of objects*): This REQUIRED property contains collection of only one [OCI descriptor][oci-descriptor] referencing signature envelope.
+- **`layers`** (*array of objects*): This REQUIRED property contains collection of only one [OCI descriptor][oci-descriptor] referencing the signature envelope.
   - **`mediaType`** (*string*): This REQUIRED property contains media type of signature envelope blob. Following values are supported
     - `application/jose+json`
     - `application/cose`

--- a/specs/signature-specification.md
+++ b/specs/signature-specification.md
@@ -51,9 +51,9 @@ Signature manifest example per OCI artifact manifest
   - **`io.cncf.notary.x509chain.thumbprint#S256`**: A REQUIRED annotation whose value contains the list of SHA-256 fingerprint of signing certificate and certificate chain (including root) used for signature generation. The annotation name contains the hash algorithm as a suffix (`#S256`) and can be extended to support other hashing algorithms in future.
     The list of fingerprints is present as a JSON array string, corresponding to ordered certificates in [*Certificate Chain* unsigned attribute](#unsigned-attributes) in the signature envelope.
 
-### Backwards Compatibility
+### Backward Compatibility
 
-Notary v2 MAY support using [OCI Image manifest][oci-image-manifest] to store the signature in the registries that implement partial or older versions of the OCI Image specification.
+Notary v2 MAY support using `OCI image manifest` to store the signature in the registries that implement partial of the [OCI image specification v1.1][oci-image-manifest].
 
 Signature manifest example per OCI image manifest:
 
@@ -64,7 +64,7 @@ Signature manifest example per OCI image manifest:
     "config": {
         "mediaType": "application/vnd.cncf.notary.signature",
         "size": 2,
-        "digest": "sha256:ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356"
+        "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
     },
     "layers": [
         {
@@ -362,5 +362,5 @@ Alternatively, an implementation of Notary v2 can choose not to implement plugin
 [ietf-rfc3161]: https://datatracker.ietf.org/doc/html/rfc3161#section-2.4.2
 [oci-artifact-manifest]: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/artifact.md
 [oci-distribution-referrers]: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers
-[oci-image-manifest]: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md
-[image-manifest-property-descriptions]: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md#image-manifest-property-descriptions
+[oci-image-manifest]: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/manifest.md
+[image-manifest-property-descriptions]: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/manifest.md#image-manifest-property-descriptions

--- a/specs/signature-specification.md
+++ b/specs/signature-specification.md
@@ -88,7 +88,7 @@ Signature manifest example per OCI image manifest:
 Besides the [image manifest property requirements][image-manifest-property-descriptions], the properties has the following additional restrictions:
 
 - **`mediaType`** (*string*): This REQUIRED property MUST be `application/vnd.oci.image.manifest.v1+json`.
-- **`config`** (*descriptor*): This REQUIRED property references a configuration object for a signature by digest. Notary v2 doesn't require specific configurations for a signature. Implementations SHOULD decide the configuration content based on their specific needs.
+- **`config`** (*descriptor*): This property is REQUIRED to be compatible with [OCI image specification][oci-image-manifest]. Notary v2 doesn't require any configurations for a signature, and the configuration contents are not consumed by Notary v2.
   - **`mediaType`** (*string*): This REQUIRED property MUST be `application/vnd.cncf.notary.signature`.
   - **`digest`** (*string*): This REQUIRED property is the digest of the targeted content.
   - **`size`** (*int64*): This REQUIRED property specifies the size, in bytes, of the raw content.


### PR DESCRIPTION
Update:
- Add a section "Backwards Compatibility" on notation support of using OCI image manifest to store signatures
- Add an example of signature manifest per OCI image manifest
- Add manifest properties requirements accordingly

Signed-off-by: Yi Zha <yizha1@microsoft.com>