### PR TITLE
Add Vani Rao as notaryproject maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vaninrao10

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Vani Rao <vaninrao@amazon.com> (@vaninrao10)


### PR DESCRIPTION
Add Vani Rao as a seed maintainer of notaryproject based on their activity and as per - https://github.com/notaryproject/notaryproject/issues/224

Signed-off-by: vaninrao10 <111005862+vaninrao10@users.noreply.github.com>