### PR TITLE
Add Shiwei Zhang as notaryproject maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @shizhMSFT

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Shiwei Zhang <shizh@microsoft.com> (@shizhMSFT)


### PR DESCRIPTION
Add Shiwei Zhang (@shizhMSFT) as a seed maintainer of `notaryproject` based on [their](https://github.com/notaryproject/notaryproject/commits?author=shizhMSFT) activity as per - https://github.com/notaryproject/notaryproject/issues/224

Signed-off-by: Yi Zha <yizha1@microsoft.com>