### PR TITLE
Add Feynman Zhou as notaryproject maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @FeynmanZhou

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Feynman Zhou <feynmanzhou@microsoft.com> (@FeynmanZhou)


### PR DESCRIPTION
Add Feynman Zhou (@FeynmanZhou) as a seed maintainer of notaryproject based on their activity as per - https://github.com/notaryproject/notaryproject/issues/224

Signed-off-by: Yi Zha <yizha1@microsoft.com>